### PR TITLE
Ci18 31

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -260,6 +260,15 @@ jib {
         image = 'azul/zulu-openjdk-alpine:17'
     }
 
+    extraDirectories {
+        paths {
+            path {
+                from = 'ff4j'
+                into = '/.fineract/ff4j'
+            }
+        }
+    }
+
     to {
         image = 'fineract'
         tags = [

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/ContentS3Config.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/ContentS3Config.java
@@ -37,6 +37,7 @@ public class ContentS3Config {
                 .withCredentials(
                         new AWSStaticCredentialsProvider(new BasicAWSCredentials(fineractProperties.getContent().getS3().getAccessKey(),
                                 fineractProperties.getContent().getS3().getSecretKey())))
+                .withRegion(fineractProperties.getContent().getS3().getRegion())
                 .build();
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/ContentS3Config.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/ContentS3Config.java
@@ -34,10 +34,8 @@ public class ContentS3Config {
     @ConditionalOnProperty("fineract.content.s3.enabled")
     public AmazonS3 contentS3Client(FineractProperties fineractProperties) {
         return AmazonS3ClientBuilder.standard()
-                .withCredentials(
-                        new AWSStaticCredentialsProvider(new BasicAWSCredentials(fineractProperties.getContent().getS3().getAccessKey(),
-                                fineractProperties.getContent().getS3().getSecretKey())))
-                .withRegion(fineractProperties.getContent().getS3().getRegion())
-                .build();
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+                        fineractProperties.getContent().getS3().getAccessKey(), fineractProperties.getContent().getS3().getSecretKey())))
+                .withRegion(fineractProperties.getContent().getS3().getRegion()).build();
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
@@ -104,5 +104,6 @@ public class FineractProperties {
         private String bucketName;
         private String accessKey;
         private String secretKey;
+        private String region;
     }
 }

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -57,6 +57,7 @@ fineract.content.filesystem.enabled=${FINERACT_CONTENT_FILESYSTEM_ENABLED:true}
 fineract.content.filesystem.rootFolder=${FINERACT_CONTENT_FILESYSTEM_ROOT_FOLDER:${user.home}/.fineract}
 fineract.content.s3.enabled=${FINERACT_CONTENT_S3_ENABLED:false}
 fineract.content.s3.bucketName=${FINERACT_CONTENT_S3_BUCKET_NAME:}
+fineract.content.s3.region=${FINERACT_CONTENT_S3_REGION:}
 fineract.content.s3.accessKey=${FINERACT_CONTENT_S3_ACCESS_KEY:}
 fineract.content.s3.secretKey=${FINERACT_CONTENT_S3_SECRET_KEY:}
 


### PR DESCRIPTION
https://fiterio.atlassian.net/browse/CI18-31

When enabling S3 bucket there was an issue with running Fineract. Region seems to be required. Also, Carbon want us to pass the region when accessing S3 bucket. This PR adds an env variable for setting region when turning on S3 bucket.

I've also, used this opportunity to add the default ff4j template to the container so you don't have to pass it as an env variable. Fineract was failing to run if this is not explicitly set.