### PR TITLE
MON-167 Indicate topup disbursement as topup

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransactionType.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransactionType.java
@@ -28,6 +28,7 @@ public enum LoanTransactionType {
     REPAYMENT_AT_DISBURSEMENT(5, "loanTransactionType.repaymentAtDisbursement"), //
     WRITEOFF(6, "loanTransactionType.writeOff"), //
     MARKED_FOR_RESCHEDULING(7, "loanTransactionType.marked.for.rescheduling"), //
+    TOP_UP(25, "loanTransactionType.topUp"),
     /**
      * This type of transactions is allowed on written-off loans where mfi still attempts to recover payments from
      * applicant after writing-off.
@@ -150,6 +151,9 @@ public enum LoanTransactionType {
             break;
             case 24:
                 loanTransactionType = LoanTransactionType.BNPL_VENDOR_TRANSFER;
+            break;
+            case 25:
+                loanTransactionType = LoanTransactionType.TOP_UP;
             break;
             default:
                 loanTransactionType = LoanTransactionType.INVALID;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -1322,7 +1322,13 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
 
         public String loanPaymentsSchema() {
 
-            return " tr.id as id, tr.transaction_type_enum as transactionType, tr.transaction_date as " + sqlGenerator.escape("date")
+            return " tr.id as id, " +
+                    " CASE "
+                    + "     WHEN mlt.id IS not null and tr.transaction_type_enum = 1 and mlt.topup_amount <> tr.amount "
+                    + "       then 25 "
+                    + "    ELSE tr.transaction_type_enum "
+                    + " END as transactionType,"
+                    + " tr.transaction_date as " + sqlGenerator.escape("date")
                     + ", tr.amount as total, " + " tr.principal_portion_derived as principal, tr.interest_portion_derived as interest, "
                     + " tr.fee_charges_portion_derived as fees, tr.penalty_charges_portion_derived as penalties, "
                     + " tr.overpayment_portion_derived as overpayment, tr.outstanding_loan_balance_derived as outstandingLoanBalance, "
@@ -1344,7 +1350,7 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
                     + " left JOIN m_payment_detail pd ON tr.payment_detail_id = pd.id"
                     + " left join m_payment_type pt on pd.payment_type_id = pt.id" + " left join m_office office on office.id=tr.office_id"
                     + " left join m_account_transfer_transaction fromtran on fromtran.from_loan_transaction_id = tr.id "
-                    + " left join m_account_transfer_transaction totran on totran.to_loan_transaction_id = tr.id ";
+                    + " left join m_account_transfer_transaction totran on totran.to_loan_transaction_id = tr.id left join m_loan_topup mlt  on mlt.loan_id = tr.loan_id ";
         }
 
         @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanEnumerations.java
@@ -431,6 +431,10 @@ public final class LoanEnumerations {
                 optionData = new LoanTransactionEnumData(LoanTransactionType.BNPL_VENDOR_TRANSFER.getValue().longValue(),
                         LoanTransactionType.BNPL_VENDOR_TRANSFER.getCode(), "BNPL Vendor Transfer");
             break;
+            case TOP_UP:
+                optionData = new LoanTransactionEnumData(LoanTransactionType.TOP_UP.getValue().longValue(),
+                        LoanTransactionType.TOP_UP.getCode(), "Top Up");
+                break;
         }
         return optionData;
     }


### PR DESCRIPTION
Currently when a loan topup is done, there are two entries for disbursement in the transaction, one for the closed loan and one for the new loan, the new loan disbursement is now marked as "Top Up" with this merge