### PR TITLE
Oxy 126

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/commands/domain/CommandSource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/commands/domain/CommandSource.java
@@ -27,9 +27,11 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.logging.log4j.util.Strings;
 
 @Entity
 @Table(name = "m_portfolio_command_source")
@@ -270,6 +272,18 @@ public class CommandSource extends AbstractPersistableCustom {
 
     public void updateTransaction(final String transactionId) {
         this.transactionId = transactionId;
+    }
+
+    public void updateActionNameAndEntityName(CommandProcessingResult commandProcessingResult){
+
+        if(commandProcessingResult != null & !Strings.isEmpty(commandProcessingResult.getActionName())){
+            this.actionName = commandProcessingResult.getActionName();
+        }
+
+        if(commandProcessingResult != null & !Strings.isEmpty(commandProcessingResult.getEntityName())){
+            this.entityName = commandProcessingResult.getEntityName();
+        }
+
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
@@ -1491,6 +1491,15 @@ public class CommandWrapperBuilder {
         return this;
     }
 
+    public CommandWrapperBuilder savingsAccountLimitWithdrawal(final Long accountId) {
+        this.actionName = "LIMITWITHDRAWAL";
+        this.entityName = "SAVINGSACCOUNT";
+        this.savingsId = accountId;
+        this.entityId = null;
+        this.href = "/savingsaccounts/" + accountId + "/transactions";
+        return this;
+    }
+
     public CommandWrapperBuilder undoSavingsAccountTransaction(final Long accountId, final Long transactionId) {
         this.actionName = "UNDOTRANSACTION";
         this.entityName = "SAVINGSACCOUNT";

--- a/fineract-provider/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
@@ -92,9 +92,11 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
             commandSourceResult = CommandSource.fullEntryFrom(wrapper, command, maker);
         }
         commandSourceResult.updateResourceId(result.resourceId());
+        commandSourceResult.updateSubresourceId(result.getSubResourceId());
         commandSourceResult.updateForAudit(result.getOfficeId(), result.getGroupId(), result.getClientId(), result.getLoanId(),
                 result.getSavingsId(), result.getProductId(), result.getTransactionId());
 
+        commandSourceResult.updateActionNameAndEntityName(result);
         String changesOnlyJson = null;
         boolean rollBack = (rollbackTransaction || result.isRollbackTransaction()) && !isApprovedByChecker;
         if (result.hasChanges() && !rollBack) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResult.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResult.java
@@ -21,6 +21,9 @@ package org.apache.fineract.infrastructure.core.data;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -36,6 +39,7 @@ public class CommandProcessingResult implements Serializable {
     private final Long loanId;
     private final Long savingsId;
     private final Long resourceId;
+    @Setter
     private final Long subResourceId;
     private final String transactionId;
     private final Map<String, Object> changes;
@@ -45,27 +49,33 @@ public class CommandProcessingResult implements Serializable {
     private final Long gsimId;
     private final Long glimId;
     private Boolean rollbackTransaction;
+    @ToString.Exclude
+    @Getter
+    private String actionName;
 
+    @ToString.Exclude
+    @Getter
+    private String entityName;
     public static CommandProcessingResult fromCommandProcessingResult(CommandProcessingResult commandResult) {
         return new CommandProcessingResult(commandResult.commandId, commandResult.officeId, commandResult.groupId, commandResult.clientId,
                 commandResult.loanId, commandResult.savingsId, commandResult.resourceIdentifier, commandResult.resourceId,
                 commandResult.transactionId, commandResult.changes, commandResult.productId, commandResult.gsimId, commandResult.glimId,
-                commandResult.creditBureauReportData, commandResult.rollbackTransaction, commandResult.subResourceId);
+                commandResult.creditBureauReportData, commandResult.rollbackTransaction, commandResult.subResourceId,commandResult.actionName);
     }
 
     public static CommandProcessingResult fromCommandProcessingResult(CommandProcessingResult commandResult, final Long resourceId) {
         return new CommandProcessingResult(commandResult.commandId, commandResult.officeId, commandResult.groupId, commandResult.clientId,
                 commandResult.loanId, commandResult.savingsId, commandResult.resourceIdentifier, resourceId, commandResult.transactionId,
                 commandResult.changes, commandResult.productId, commandResult.gsimId, commandResult.glimId,
-                commandResult.creditBureauReportData, commandResult.rollbackTransaction, commandResult.subResourceId);
+                commandResult.creditBureauReportData, commandResult.rollbackTransaction, commandResult.subResourceId,commandResult.actionName);
     }
 
     public static CommandProcessingResult fromDetails(final Long commandId, final Long officeId, final Long groupId, final Long clientId,
             final Long loanId, final Long savingsId, final String resourceIdentifier, final Long entityId, final Long gsimId,
             final Long glimId, final Map<String, Object> creditBureauReportData, final String transactionId,
-            final Map<String, Object> changes, final Long productId, final Boolean rollbackTransaction, final Long subResourceId) {
+            final Map<String, Object> changes, final Long productId, final Boolean rollbackTransaction, final Long subResourceId,final String actionName) {
         return new CommandProcessingResult(commandId, officeId, groupId, clientId, loanId, savingsId, resourceIdentifier, entityId,
-                transactionId, changes, productId, gsimId, glimId, creditBureauReportData, rollbackTransaction, subResourceId);
+                transactionId, changes, productId, gsimId, glimId, creditBureauReportData, rollbackTransaction, subResourceId,actionName);
     }
 
     public static CommandProcessingResult commandOnlyResult(final Long commandId) {
@@ -124,7 +134,7 @@ public class CommandProcessingResult implements Serializable {
     private CommandProcessingResult(final Long commandId, final Long officeId, final Long groupId, final Long clientId, final Long loanId,
             final Long savingsId, final String resourceIdentifier, final Long resourceId, final String transactionId,
             final Map<String, Object> changesOnly, final Long productId, final Long gsimId, final Long glimId,
-            final Map<String, Object> creditBureauReportData, Boolean rollbackTransaction, final Long subResourceId) {
+            final Map<String, Object> creditBureauReportData, Boolean rollbackTransaction, final Long subResourceId,final String actionName) {
         this.commandId = commandId;
         this.officeId = officeId;
         this.groupId = groupId;
@@ -141,6 +151,7 @@ public class CommandProcessingResult implements Serializable {
         this.creditBureauReportData = creditBureauReportData;
         this.rollbackTransaction = rollbackTransaction;
         this.subResourceId = subResourceId;
+        this.actionName = actionName;
     }
 
     protected CommandProcessingResult(final Long resourceId, final Long officeId, final Long commandId,
@@ -168,7 +179,7 @@ public class CommandProcessingResult implements Serializable {
 
     protected CommandProcessingResult(final Long resourceId, final Long officeId, final Long commandId,
             final Map<String, Object> changesOnly, long clientId) {
-        this(commandId, officeId, null, clientId, null, null, null, resourceId, null, changesOnly, null, null, null, null, null, null);
+        this(commandId, officeId, null, clientId, null, null, null, resourceId, null, changesOnly, null, null, null, null, null, null,null);
     }
 
     public Long commandId() {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResultBuilder.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/data/CommandProcessingResultBuilder.java
@@ -42,10 +42,14 @@ public class CommandProcessingResultBuilder {
     private Long productId;
     private boolean rollbackTransaction = false;
 
+    private String actionName;
+
+    private String entityName;
+
     public CommandProcessingResult build() {
         return CommandProcessingResult.fromDetails(this.commandId, this.officeId, this.groupId, this.clientId, this.loanId, this.savingsId,
                 this.resourceIdentifier, this.entityId, this.gsimId, this.glimId, this.creditBureauReportData, this.transactionId,
-                this.changes, this.productId, this.rollbackTransaction, this.subEntityId);
+                this.changes, this.productId, this.rollbackTransaction, this.subEntityId,this.actionName);
     }
 
     public CommandProcessingResultBuilder withCommandId(final Long withCommandId) {
@@ -125,6 +129,16 @@ public class CommandProcessingResultBuilder {
 
     public CommandProcessingResultBuilder setRollbackTransaction(final boolean rollbackTransaction) {
         this.rollbackTransaction = this.rollbackTransaction || rollbackTransaction;
+        return this;
+    }
+
+    public CommandProcessingResultBuilder withActionName(final String actionName) {
+        this.actionName = actionName;
+        return this;
+    }
+
+    public CommandProcessingResultBuilder withEntityName(final String entityName) {
+        this.entityName = entityName;
         return this;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/TransactionHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/TransactionHandler.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.function.Supplier;
+
+@Service
+public class TransactionHandler {
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public <T> T runInTransaction(Supplier<T> supplier) {
+        return supplier.get();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public <T> T runInNewTransaction(Supplier<T> supplier) {
+        return supplier.get();
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public <T> T pauseTransactionAndRun(Supplier<T> supplier) {
+        return supplier.get();
+    }
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountDomainServiceJpa.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.fineract.accounting.journalentry.service.JournalEntryWritePlatformService;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.configuration.domain.GlobalConfigurationRepositoryWrapper;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.organisation.monetary.domain.ApplicationCurrency;
@@ -70,8 +71,9 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
     private final LoanReadPlatformService loanReadPlatformService;
 
     private final SavingsAccountAssembler savingAccountAssembler;
-
     private final SavingsAccountTransactionDataValidator savingsAccountTransactionDataValidator;
+
+    private final GlobalConfigurationRepositoryWrapper globalConfigurationRepository;
 
     @Autowired
     public SavingsAccountDomainServiceJpa(final SavingsAccountRepositoryWrapper savingsAccountRepository,
@@ -82,7 +84,8 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
             final DepositAccountOnHoldTransactionRepository depositAccountOnHoldTransactionRepository,
             final BusinessEventNotifierService businessEventNotifierService,
             final SavingsAccountTransactionDataValidator savingsAccountTransactionDataValidator,
-            final SavingsAccountAssembler savingAccountAssembler, final LoanReadPlatformService loanReadPlatformService) {
+            final SavingsAccountAssembler savingAccountAssembler, final LoanReadPlatformService loanReadPlatformService,
+                                          final GlobalConfigurationRepositoryWrapper globalConfigurationRepository) {
 
         this.savingsAccountRepository = savingsAccountRepository;
         this.savingsAccountTransactionRepository = savingsAccountTransactionRepository;
@@ -95,6 +98,7 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
         this.savingsAccountTransactionDataValidator = savingsAccountTransactionDataValidator;
         this.savingAccountAssembler = savingAccountAssembler;
         this.loanReadPlatformService = loanReadPlatformService;
+        this.globalConfigurationRepository = globalConfigurationRepository;
     }
 
     private BigDecimal getOverdueLoanAmountForClient(SavingsAccount savingsAccount, boolean isTransferToLoanAccount) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionPending.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionPending.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.portfolio.savings.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.apache.fineract.infrastructure.core.domain.AbstractAuditableCustom;
+import org.apache.fineract.portfolio.client.domain.Client;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.math.BigDecimal;
+
+@lombok.Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "m_savings_account_transaction_pending")
+public class SavingsAccountTransactionPending  extends AbstractAuditableCustom {
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "savings_account_id", referencedColumnName = "id")
+        private SavingsAccount savingsAccount;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "committed_transaction_id", referencedColumnName = "id")
+        private SavingsAccountTransaction committedTransaction;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "client_id", referencedColumnName = "id")
+        private Client client;
+
+        @Column(name = "transaction_type_enum")
+        private Integer transactionTypeEnum;
+
+        @Column(name = "amount")
+        private BigDecimal amount;
+
+        @Column(name = "locale")
+        private String locale;
+
+        @Column(name = "currency_code")
+        private String currencyCode;
+
+        @Column(name = "external_id")
+        private String externalId;
+
+        @Column(name = "is_processed")
+        private Boolean isProcessed;
+
+        public static SavingsAccountTransactionPending createNew(final SavingsAccountTransaction savingsAccountTransaction,
+                final SavingsAccount savingsAccount, final Client client, final String externalId, final String locale) {
+            return new SavingsAccountTransactionPending(savingsAccount, null, client, savingsAccountTransaction.getTypeOf(), savingsAccountTransaction.getAmount(),
+                    locale, savingsAccount.getCurrency().getCode(), externalId, false);
+        }
+
+        public void updateCommittedTransaction(final SavingsAccountTransaction committedTransaction) {
+                this.isProcessed = true;
+                this.committedTransaction = committedTransaction;
+        }
+    }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionPendingRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionPendingRepository.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface SavingsAccountTransactionPendingRepository
+        extends JpaRepository<SavingsAccountTransactionPending, Long>, JpaSpecificationExecutor<SavingsAccountTransactionPending> {
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/handler/WithdrawWithLimitSavingsAccountCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/handler/WithdrawWithLimitSavingsAccountCommandHandler.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.handler;
+
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.handler.NewCommandSourceHandler;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.portfolio.savings.service.SavingsAccountWritePlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@CommandType(entity = "SAVINGSACCOUNT", action = "WITHDRAWAL_WITH_LIMIT")
+public class WithdrawWithLimitSavingsAccountCommandHandler implements NewCommandSourceHandler {
+
+    private final SavingsAccountWritePlatformService writePlatformService;
+
+    @Autowired
+    public WithdrawWithLimitSavingsAccountCommandHandler(final SavingsAccountWritePlatformService writePlatformService) {
+        this.writePlatformService = writePlatformService;
+    }
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(final JsonCommand command) {
+        return this.writePlatformService.withdrawal(command.getSavingsId(), command);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTransactionLimitPlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTransactionLimitPlatformService.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.portfolio.savings.service;
+
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.apache.fineract.portfolio.client.domain.Client;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
+
+public interface SavingsAccountTransactionLimitPlatformService {
+
+    void handleApprovalsForSessionTransactionLimits(final JsonCommand command, final SavingsAccount savingsAccount, final SavingsAccountTransaction savingsAccountTransaction, final Client client,final CommandProcessingResultBuilder result);
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTransactionLimitPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTransactionLimitPlatformServiceImpl.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.portfolio.savings.service;
+
+import org.apache.fineract.infrastructure.configuration.domain.GlobalConfigurationProperty;
+import org.apache.fineract.infrastructure.configuration.domain.GlobalConfigurationRepositoryWrapper;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.apache.fineract.infrastructure.core.exception.PlatformServiceUnavailableException;
+import org.apache.fineract.infrastructure.core.service.TransactionHandler;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.client.domain.Client;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionPending;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionPendingRepository;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@lombok.RequiredArgsConstructor
+public class SavingsAccountTransactionLimitPlatformServiceImpl implements SavingsAccountTransactionLimitPlatformService{
+
+    private final GlobalConfigurationRepositoryWrapper globalConfigurationRepositoryWrapper;
+    private final SavingsAccountTransactionPendingRepository savingsAccountTransactionPendingRepository;
+    private final PlatformSecurityContext context;
+    private final TransactionHandler transactionHandler;
+
+
+    @Override
+    public void handleApprovalsForSessionTransactionLimits(final JsonCommand command, final SavingsAccount savingsAccount, final SavingsAccountTransaction savingsAccountTransaction, final Client client,final CommandProcessingResultBuilder builder) {
+
+        GlobalConfigurationProperty maxWithdrawPerSessionConfig = this.globalConfigurationRepositoryWrapper.findOneByNameWithNotFoundDetection("max-withdraw-amount-per-session");
+        if (maxWithdrawPerSessionConfig.isEnabled() && maxWithdrawPerSessionConfig.getValue() > 0l && command.entityId() == null
+                && maxWithdrawPerSessionConfig.getValue() < savingsAccountTransaction.getAmount().longValue()){
+            //check if max withdraw limit is per session is configured
+            transactionHandler.pauseTransactionAndRun(() -> {
+                SavingsAccountTransactionPending transactionPendingApproval = SavingsAccountTransactionPending.createNew(savingsAccountTransaction, savingsAccount, client, null, command.locale());
+                this.savingsAccountTransactionPendingRepository.saveAndFlush(transactionPendingApproval);
+                builder.setRollbackTransaction(true);
+                builder.withSubEntityId(transactionPendingApproval.getId());
+                builder.withActionName("WITHDRAWAL_WITH_LIMIT");
+                return null;
+            });
+        }
+
+        if(maxWithdrawPerSessionConfig.isEnabled() && maxWithdrawPerSessionConfig.getValue() > 0l && command.entityId() != null
+                && maxWithdrawPerSessionConfig.getValue() < savingsAccountTransaction.getAmount().longValue()){
+
+            //Check that app user has specific permission APPROVEWITHDRAWAL
+
+            transactionHandler.runInTransaction(() -> {
+                final AppUser currentUser = this.context.authenticatedUser();
+                final boolean hasPermission = currentUser.hasSpecificPermissionTo("WITHDRAWAL_WITH_LIMIT_SAVINGSACCOUNT_CHECKER");
+                if(!hasPermission){
+                    throw new PlatformServiceUnavailableException("error.msg.savings.account.transaction.approve.withdrawal.permission", "User does not have permission to approve limit withdrawal");
+                }
+
+                SavingsAccountTransactionPending transactionPendingApproval = this.savingsAccountTransactionPendingRepository.findById(command.subentityId()).orElse(null);
+                if(transactionPendingApproval == null){
+                    throw new PlatformServiceUnavailableException("error.msg.savings.account.transaction.approve.withdrawal.not.found", "Transaction Pending Approval not found");
+                }
+                transactionPendingApproval.updateCommittedTransaction(savingsAccountTransaction);
+                this.savingsAccountTransactionPendingRepository.saveAndFlush(transactionPendingApproval);
+                return null;
+            });
+
+        }
+    }
+}

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -84,4 +84,6 @@
     <include file="parts/OXY-118-BNPL_attributes_for_loan.xml" relativeToChangelogFile="true" />
     <include file="parts/CI18-127_add_product_categories_and_product_type_column.xml" relativeToChangelogFile="true" />
     <include file="parts/OXY-83_flexi_account_withdrawal_window.xml" relativeToChangelogFile="true" />
+    <include file="parts/OXY-137_add_max_withdrawal_global_config.xml" relativeToChangelogFile="true" />
+    <include file="parts/OXY-138_add_on_hold_table_for_savings_account.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/OXY-137_add_max_withdrawal_global_config.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/OXY-137_add_max_withdrawal_global_config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="naphlin@fiter.io" id="add_global_configuration_for_limit_of_withdraw_amount">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="1">
+                    SELECT COUNT(1) FROM c_configuration WHERE name = 'max-withdraw-amount-per-session'
+                </sqlCheck>
+            </not>
+        </preConditions>
+
+        <insert tableName="c_configuration">
+            <column name="name" value="max-withdraw-amount-per-session" />
+            <column name="value" value="0" />
+            <column name="enabled" valueBoolean="0" />
+            <column name="description" value="Allows limiting of max withdraw amount for a client" />
+
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/OXY-138_add_on_hold_table_for_savings_account.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/OXY-138_add_on_hold_table_for_savings_account.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+<changeSet author="naphlin@fiter.io" id="add_savings_withdraw_pending_trans_table">
+    <preConditions onFail="MARK_RAN">
+        <not>
+            <tableExists tableName="m_savings_account_transaction_pending"/>
+        </not>
+    </preConditions>
+    <createTable tableName="m_savings_account_transaction_pending">
+        <column name="id" type="BIGINT" autoIncrement="true">
+            <constraints primaryKey="true" nullable="false"/>
+        </column>
+        <column name="savings_account_id" type="BIGINT">
+            <constraints nullable="false" foreignKeyName="FK_m_savings_account_sv_pending" references="m_savings_account(id)"/>
+        </column>
+        <column name="committed_transaction_id" type="BIGINT">
+            <constraints nullable="true" foreignKeyName="FK_m_savings_account_transaction_transaction_pending" references="m_savings_account_transaction(id)"/>
+        </column>
+        <column name="client_id" type="BIGINT">
+            <constraints nullable="true" foreignKeyName="FK_client_transaction_on_hold" references="m_client(id)"/>
+        </column>
+        <column name="transaction_type_enum" type="INTEGER">
+            <constraints nullable="false"/>
+        </column>
+        <column name="amount" type="DECIMAL(19,6)">
+            <constraints nullable="false"/>
+        </column>
+        <column name="locale" type="VARCHAR(50)">
+            <constraints nullable="false"/>
+        </column>
+        <column name="currency_code" type="VARCHAR(3)">
+            <constraints nullable="false"/>
+        </column>
+        <column name="external_id" type="VARCHAR(100)">
+            <constraints nullable="true"/>
+        </column>
+        <column name="is_processed" type="boolean">
+            <constraints nullable="false"/>
+        </column>
+        <column name="createdby_id" type="BIGINT">
+            <constraints nullable="false"/>
+        </column>
+        <column name="created_date" type="TIMESTAMP">
+            <constraints nullable="false"/>
+        </column>
+        <column name="lastmodified_date" type="TIMESTAMP">
+            <constraints nullable="false"/>
+        </column>
+        <column name="lastmodifiedby_id" type="BIGINT">
+            <constraints nullable="false"/>
+        </column>
+    </createTable>
+</changeSet>
+
+    <changeSet id="add_permission_for_limit_withdrawal" author="naphlin@fiter.io">
+        <!-- Add permission for limit withdrawal -->
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM m_permission WHERE code = 'WITHDRAWAL_WITH_LIMIT_SAVINGSACCOUNT_CHECKER';
+            </sqlCheck>
+        </preConditions>
+        <insert tableName="m_permission">
+            <column name="grouping" value="transaction_savings"/>
+            <column name="code" value="WITHDRAWAL_WITH_LIMIT_SAVINGSACCOUNT_CHECKER"/>
+            <column name="entity_name" value="SAVINGSACCOUNT"/>
+            <column name="action_name" value="WITHDRAWAL_WITH_LIMIT_CHECKER"/>
+            <column name="can_maker_checker" value="0"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="add_permission_for_limit_withdrawal_2" author="naphlin@fiter.io">
+        <!-- Add permission for limit withdrawal -->
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM m_permission WHERE code = 'WITHDRAWAL_WITH_LIMIT_SAVINGSACCOUNT';
+            </sqlCheck>
+        </preConditions>
+        <insert tableName="m_permission">
+            <column name="grouping" value="transaction_savings"/>
+            <column name="code" value="WITHDRAWAL_WITH_LIMIT_SAVINGSACCOUNT"/>
+            <column name="entity_name" value="SAVINGSACCOUNT"/>
+            <column name="action_name" value="WITHDRAWAL_WITH_LIMIT"/>
+            <column name="can_maker_checker" value="0"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Currently permissions that are not linked to commands and apis are not supported.The change adds support for dynamically injected permissions to force checker operations based on certain conditions that are not supported from the api (in this case approval requirement for savings withdrawal beyond a given limit).
When this is done, same approval flow required for maker checker operations gets to be used.