### PR TITLE
CI18-129: Make adjustment to overdraft feature

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
@@ -123,4 +123,9 @@ public interface ConfigurationDomainService {
 
     boolean enforceOverdueLoansForMinBalance();
 
+    boolean isPostOverdraftInterestOnDepositEnabled();
+
+    boolean isMaxActiveLoansEnabled();
+
+    Long getMaxActiveLoans();
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
@@ -468,4 +468,24 @@ public class ConfigurationDomainServiceJpa implements ConfigurationDomainService
     public boolean isClientLevelValidationEnabled() {
         return this.ff4j.check(FeatureList.CLIENT_LEVEL_LIMIT_VALIDATION);
     }
+
+    @Override
+    public boolean isPostOverdraftInterestOnDepositEnabled() {
+        return getGlobalConfigurationPropertyData("post-overdraft-interest-on-deposit").isEnabled();
+    }
+
+    @Override
+    public boolean isMaxActiveLoansEnabled() {
+        return getGlobalConfigurationPropertyData("max-active-loans").isEnabled();
+    }
+
+    @Override
+    public Long getMaxActiveLoans() {
+        final String propertyName = "max-active-loans";
+        final GlobalConfigurationPropertyData property = getGlobalConfigurationPropertyData(propertyName);
+        if (property.getValue() == null) {
+            return 0L;
+        }
+        return property.getValue();
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/data/LoanAccountSummaryData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/accountdetails/data/LoanAccountSummaryData.java
@@ -86,4 +86,8 @@ public class LoanAccountSummaryData {
         this.originalLoan = originalLoan;
         this.amountPaid = amountPaid;
     }
+
+    public LoanStatusEnumData getStatus() {
+        return status;
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformService.java
@@ -155,6 +155,8 @@ public interface LoanReadPlatformService {
 
     List<LoanRepaymentScheduleInstallmentData> getRepaymentDataResponse(Long loanId);
 
+    Integer retrieveNumberOfActiveLoansByClientId(Long clientId);
+
     CollectionData retrieveLoanCollectionData(Long loanId);
 
     List<LoanAccountData> retrieveOverDueLoansForClient(Long client);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -2376,6 +2376,12 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
     }
 
     @Override
+    public Integer retrieveNumberOfActiveLoansByClientId(Long clientId) {
+        final String sql = "select count(*) from m_loan where client_id = ? and (loan_status_id = 300 or loan_status_id = 301)";
+        return this.jdbcTemplate.queryForObject(sql, Integer.class, clientId);
+    }
+
+    @Override
     public CollectionData retrieveLoanCollectionData(Long loanId) {
         final CollectionDataMapper mapper = new CollectionDataMapper(sqlGenerator);
         String sql = "select " + mapper.schema();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
@@ -132,6 +132,7 @@ public class SavingsApiConstants {
     public static final String bankNumberParamName = "bankNumber";
     public static final String allowOverdraftParamName = "allowOverdraft";
     public static final String overdraftLimitParamName = "overdraftLimit";
+    public static final String postOverdraftInterestOnDepositParamName = "postOverdraftInterestOnDeposit";
     public static final String nominalAnnualInterestRateOverdraftParamName = "nominalAnnualInterestRateOverdraft";
     public static final String minOverdraftForInterestCalculationParamName = "minOverdraftForInterestCalculation";
     public static final String minRequiredBalanceParamName = "minRequiredBalance";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResource.java
@@ -315,6 +315,7 @@ public class SavingsAccountsApiResource {
         savingsAccountData.setFloatingInterestRates(floatingInterestRates);
         savingsAccountData.setUseFloatingInterestRate(savingsAccount.getUseFloatingInterestRate());
         savingsAccountData.setTransactionSize(transactionSize);
+        savingsAccountData.setPostOverdraftInterestOnDeposit(savingsAccount.isPostOverdraftInterestOnDeposit());
         return savingsAccountData;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountConstant.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountConstant.java
@@ -40,7 +40,7 @@ public class SavingsAccountConstant extends SavingsApiConstants {
             nominalAnnualInterestRateOverdraftParamName, minOverdraftForInterestCalculationParamName, withHoldTaxParamName, datatables,
             gsimApplicationId, gsimLastApplication, VAULT_TARGET_AMOUNT, VAULT_TARGET_DATE, useFloatingInterestRateParamName,
             floatingInterestRatesParamName, SavingsApiConstants.WITHDRAWAL_FREQUENCY_ENUM, SavingsApiConstants.WITHDRAWAL_FREQUENCY,
-            SavingsApiConstants.WITHDRAWAL_FREQUENCY_OPTIONS));
+            SavingsApiConstants.WITHDRAWAL_FREQUENCY_OPTIONS, postOverdraftInterestOnDepositParamName));
 
     protected static final Set<String> ADD_MORE_MEMBERS_TO_VAULT_TRIBE_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(
             localeParamName, isGSIM, clientIdParamName, groupIdParamName, productIdParamName, nominalAnnualInterestRateParamName,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountData.java
@@ -80,6 +80,7 @@ public final class SavingsAccountData implements Serializable {
     private final boolean allowOverdraft;
     private final BigDecimal overdraftLimit;
     private final BigDecimal minRequiredBalance;
+    private boolean postOverdraftInterestOnDeposit;
     private final boolean enforceMinRequiredBalance;
     private final BigDecimal maxAllowedLienLimit;
     private final boolean lienAllowed;
@@ -1245,5 +1246,13 @@ public final class SavingsAccountData implements Serializable {
 
     public void setNextFlexWithdrawalDate(LocalDate nextFlexWithdrawalDate) {
         this.nextFlexWithdrawalDate = nextFlexWithdrawalDate;
+    }
+
+    public void setPostOverdraftInterestOnDeposit(boolean postOverdraftInterestOnDeposit) {
+        this.postOverdraftInterestOnDeposit = postOverdraftInterestOnDeposit;
+    }
+
+    public boolean isPostOverdraftInterestOnDeposit() {
+        return this.postOverdraftInterestOnDeposit;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsProductData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsProductData.java
@@ -55,6 +55,7 @@ public final class SavingsProductData implements Serializable {
     private final boolean withdrawalFeeForTransfers;
     private final boolean allowOverdraft;
     private final BigDecimal overdraftLimit;
+    private boolean postOverdraftInterestOnDeposit;
     private final BigDecimal minRequiredBalance;
     private final boolean enforceMinRequiredBalance;
     private final BigDecimal maxAllowedLienLimit;
@@ -181,36 +182,40 @@ public final class SavingsProductData implements Serializable {
 
     public static SavingsProductData withFloatingInterestRates(final SavingsProductData product,
             final Collection<SavingsProductFloatingInterestRateData> floatingInterestRates) {
-        return new SavingsProductData(product.id, product.name, product.shortName, product.description, product.currency,
-                product.nominalAnnualInterestRate, product.interestCompoundingPeriodType, product.interestPostingPeriodType,
-                product.interestCalculationType, product.interestCalculationDaysInYearType, product.minRequiredOpeningBalance,
-                product.lockinPeriodFrequency, product.lockinPeriodFrequencyType, product.withdrawalFeeForTransfers, product.accountingRule,
-                product.accountingMappings, product.paymentChannelToFundSourceMappings, product.currencyOptions,
-                product.interestCompoundingPeriodTypeOptions, product.interestPostingPeriodTypeOptions,
-                product.interestCalculationTypeOptions, product.interestCalculationDaysInYearTypeOptions,
-                product.lockinPeriodFrequencyTypeOptions, product.withdrawalFeeTypeOptions, product.paymentTypeOptions,
-                product.accountingRuleOptions, product.accountingMappingOptions, product.charges, product.chargeOptions,
-                product.penaltyOptions, product.feeToIncomeAccountMappings, product.penaltyToIncomeAccountMappings, product.allowOverdraft,
-                product.overdraftLimit, product.minRequiredBalance, product.enforceMinRequiredBalance, product.maxAllowedLienLimit,
-                product.lienAllowed, product.minBalanceForInterestCalculation, product.nominalAnnualInterestRateOverdraft,
+        SavingsProductData productData = new SavingsProductData(product.id, product.name, product.shortName, product.description,
+                product.currency, product.nominalAnnualInterestRate, product.interestCompoundingPeriodType,
+                product.interestPostingPeriodType, product.interestCalculationType, product.interestCalculationDaysInYearType,
+                product.minRequiredOpeningBalance, product.lockinPeriodFrequency, product.lockinPeriodFrequencyType,
+                product.withdrawalFeeForTransfers, product.accountingRule, product.accountingMappings,
+                product.paymentChannelToFundSourceMappings, product.currencyOptions, product.interestCompoundingPeriodTypeOptions,
+                product.interestPostingPeriodTypeOptions, product.interestCalculationTypeOptions,
+                product.interestCalculationDaysInYearTypeOptions, product.lockinPeriodFrequencyTypeOptions,
+                product.withdrawalFeeTypeOptions, product.paymentTypeOptions, product.accountingRuleOptions,
+                product.accountingMappingOptions, product.charges, product.chargeOptions, product.penaltyOptions,
+                product.feeToIncomeAccountMappings, product.penaltyToIncomeAccountMappings, product.allowOverdraft, product.overdraftLimit,
+                product.minRequiredBalance, product.enforceMinRequiredBalance, product.maxAllowedLienLimit, product.lienAllowed,
+                product.minBalanceForInterestCalculation, product.nominalAnnualInterestRateOverdraft,
                 product.minOverdraftForInterestCalculation, product.withHoldTax, product.taxGroup, product.taxGroupOptions,
                 product.isDormancyTrackingActive, product.daysToInactive, product.daysToDormancy, product.daysToEscheat,
                 product.accountMappingForPayment, product.isInterestPostingConfigUpdate, product.numOfCreditTransaction,
                 product.numOfDebitTransaction, product.useFloatingInterestRate, floatingInterestRates, product.withdrawalFrequencyEnum,
                 product.withdrawalFrequencyOptions, product.withdrawalFrequency, product.productCategoryId, product.productTypeId,
                 product.productCategories, product.productTypes);
+        productData.setPostOverdraftInterestOnDeposit(product.postOverdraftInterestOnDeposit);
+        return productData;
     }
 
     public static SavingsProductData withCharges(final SavingsProductData product, final Collection<ChargeData> charges) {
-        return new SavingsProductData(product.id, product.name, product.shortName, product.description, product.currency,
-                product.nominalAnnualInterestRate, product.interestCompoundingPeriodType, product.interestPostingPeriodType,
-                product.interestCalculationType, product.interestCalculationDaysInYearType, product.minRequiredOpeningBalance,
-                product.lockinPeriodFrequency, product.lockinPeriodFrequencyType, product.withdrawalFeeForTransfers, product.accountingRule,
-                product.accountingMappings, product.paymentChannelToFundSourceMappings, product.currencyOptions,
-                product.interestCompoundingPeriodTypeOptions, product.interestPostingPeriodTypeOptions,
-                product.interestCalculationTypeOptions, product.interestCalculationDaysInYearTypeOptions,
-                product.lockinPeriodFrequencyTypeOptions, product.withdrawalFeeTypeOptions, product.paymentTypeOptions,
-                product.accountingRuleOptions, product.accountingMappingOptions, charges, product.chargeOptions, product.penaltyOptions,
+        SavingsProductData productData = new SavingsProductData(product.id, product.name, product.shortName, product.description,
+                product.currency, product.nominalAnnualInterestRate, product.interestCompoundingPeriodType,
+                product.interestPostingPeriodType, product.interestCalculationType, product.interestCalculationDaysInYearType,
+                product.minRequiredOpeningBalance, product.lockinPeriodFrequency, product.lockinPeriodFrequencyType,
+                product.withdrawalFeeForTransfers, product.accountingRule, product.accountingMappings,
+                product.paymentChannelToFundSourceMappings, product.currencyOptions, product.interestCompoundingPeriodTypeOptions,
+                product.interestPostingPeriodTypeOptions, product.interestCalculationTypeOptions,
+                product.interestCalculationDaysInYearTypeOptions, product.lockinPeriodFrequencyTypeOptions,
+                product.withdrawalFeeTypeOptions, product.paymentTypeOptions, product.accountingRuleOptions,
+                product.accountingMappingOptions, charges, product.chargeOptions, product.penaltyOptions,
                 product.feeToIncomeAccountMappings, product.penaltyToIncomeAccountMappings, product.allowOverdraft, product.overdraftLimit,
                 product.minRequiredBalance, product.enforceMinRequiredBalance, product.maxAllowedLienLimit, product.lienAllowed,
                 product.minBalanceForInterestCalculation, product.nominalAnnualInterestRateOverdraft,
@@ -220,6 +225,8 @@ public final class SavingsProductData implements Serializable {
                 product.numOfDebitTransaction, product.useFloatingInterestRate, product.floatingInterestRates,
                 product.withdrawalFrequencyEnum, product.withdrawalFrequencyOptions, product.getWithdrawalFrequency(),
                 product.productCategoryId, product.productTypeId, product.productCategories, product.productTypes);
+        productData.setPostOverdraftInterestOnDeposit(product.postOverdraftInterestOnDeposit);
+        return productData;
     }
 
     /**
@@ -244,15 +251,16 @@ public final class SavingsProductData implements Serializable {
             EnumOptionData withdrawalFrequencyEnum, Collection<EnumOptionData> withdrawalFrequencyOptions,
             final List<CodeValueData> productCategories, final List<CodeValueData> productTypes) {
 
-        return new SavingsProductData(existingProduct.id, existingProduct.name, existingProduct.shortName, existingProduct.description,
-                existingProduct.currency, existingProduct.nominalAnnualInterestRate, existingProduct.interestCompoundingPeriodType,
-                existingProduct.interestPostingPeriodType, existingProduct.interestCalculationType,
-                existingProduct.interestCalculationDaysInYearType, existingProduct.minRequiredOpeningBalance,
-                existingProduct.lockinPeriodFrequency, existingProduct.lockinPeriodFrequencyType, existingProduct.withdrawalFeeForTransfers,
-                existingProduct.accountingRule, existingProduct.accountingMappings, existingProduct.paymentChannelToFundSourceMappings,
-                currencyOptions, interestCompoundingPeriodTypeOptions, interestPostingPeriodTypeOptions, interestCalculationTypeOptions,
-                interestCalculationDaysInYearTypeOptions, lockinPeriodFrequencyTypeOptions, withdrawalFeeTypeOptions, paymentTypeOptions,
-                accountingRuleOptions, accountingMappingOptions, existingProduct.charges, chargeOptions, penaltyOptions,
+        SavingsProductData productData = new SavingsProductData(existingProduct.id, existingProduct.name, existingProduct.shortName,
+                existingProduct.description, existingProduct.currency, existingProduct.nominalAnnualInterestRate,
+                existingProduct.interestCompoundingPeriodType, existingProduct.interestPostingPeriodType,
+                existingProduct.interestCalculationType, existingProduct.interestCalculationDaysInYearType,
+                existingProduct.minRequiredOpeningBalance, existingProduct.lockinPeriodFrequency, existingProduct.lockinPeriodFrequencyType,
+                existingProduct.withdrawalFeeForTransfers, existingProduct.accountingRule, existingProduct.accountingMappings,
+                existingProduct.paymentChannelToFundSourceMappings, currencyOptions, interestCompoundingPeriodTypeOptions,
+                interestPostingPeriodTypeOptions, interestCalculationTypeOptions, interestCalculationDaysInYearTypeOptions,
+                lockinPeriodFrequencyTypeOptions, withdrawalFeeTypeOptions, paymentTypeOptions, accountingRuleOptions,
+                accountingMappingOptions, existingProduct.charges, chargeOptions, penaltyOptions,
                 existingProduct.feeToIncomeAccountMappings, existingProduct.penaltyToIncomeAccountMappings, existingProduct.allowOverdraft,
                 existingProduct.overdraftLimit, existingProduct.minRequiredBalance, existingProduct.enforceMinRequiredBalance,
                 existingProduct.maxAllowedLienLimit, existingProduct.lienAllowed, existingProduct.minBalanceForInterestCalculation,
@@ -263,6 +271,8 @@ public final class SavingsProductData implements Serializable {
                 existingProduct.numOfDebitTransaction, existingProduct.useFloatingInterestRate, existingProduct.floatingInterestRates,
                 withdrawalFrequencyEnum, withdrawalFrequencyOptions, existingProduct.getWithdrawalFrequency(),
                 existingProduct.productCategoryId, existingProduct.productTypeId, productCategories, productTypes);
+        productData.setPostOverdraftInterestOnDeposit(existingProduct.postOverdraftInterestOnDeposit);
+        return productData;
     }
 
     public static SavingsProductData withAccountingDetails(final SavingsProductData existingProduct,
@@ -283,18 +293,18 @@ public final class SavingsProductData implements Serializable {
         final Collection<ChargeData> chargeOptions = null;
         final Collection<ChargeData> penaltyOptions = null;
 
-        return new SavingsProductData(existingProduct.id, existingProduct.name, existingProduct.shortName, existingProduct.description,
-                existingProduct.currency, existingProduct.nominalAnnualInterestRate, existingProduct.interestCompoundingPeriodType,
-                existingProduct.interestPostingPeriodType, existingProduct.interestCalculationType,
-                existingProduct.interestCalculationDaysInYearType, existingProduct.minRequiredOpeningBalance,
-                existingProduct.lockinPeriodFrequency, existingProduct.lockinPeriodFrequencyType, existingProduct.withdrawalFeeForTransfers,
-                existingProduct.accountingRule, accountingMappings, paymentChannelToFundSourceMappings, currencyOptions,
-                interestCompoundingPeriodTypeOptions, interestPostingPeriodTypeOptions, interestCalculationTypeOptions,
-                interestCalculationDaysInYearTypeOptions, lockinPeriodFrequencyTypeOptions, withdrawalFeeTypeOptions, paymentTypeOptions,
-                accountingRuleOptions, accountingMappingOptions, existingProduct.charges, chargeOptions, penaltyOptions,
-                feeToIncomeAccountMappings, penaltyToIncomeAccountMappings, existingProduct.allowOverdraft, existingProduct.overdraftLimit,
-                existingProduct.minRequiredBalance, existingProduct.enforceMinRequiredBalance, existingProduct.maxAllowedLienLimit,
-                existingProduct.lienAllowed, existingProduct.minBalanceForInterestCalculation,
+        SavingsProductData productData = new SavingsProductData(existingProduct.id, existingProduct.name, existingProduct.shortName,
+                existingProduct.description, existingProduct.currency, existingProduct.nominalAnnualInterestRate,
+                existingProduct.interestCompoundingPeriodType, existingProduct.interestPostingPeriodType,
+                existingProduct.interestCalculationType, existingProduct.interestCalculationDaysInYearType,
+                existingProduct.minRequiredOpeningBalance, existingProduct.lockinPeriodFrequency, existingProduct.lockinPeriodFrequencyType,
+                existingProduct.withdrawalFeeForTransfers, existingProduct.accountingRule, accountingMappings,
+                paymentChannelToFundSourceMappings, currencyOptions, interestCompoundingPeriodTypeOptions, interestPostingPeriodTypeOptions,
+                interestCalculationTypeOptions, interestCalculationDaysInYearTypeOptions, lockinPeriodFrequencyTypeOptions,
+                withdrawalFeeTypeOptions, paymentTypeOptions, accountingRuleOptions, accountingMappingOptions, existingProduct.charges,
+                chargeOptions, penaltyOptions, feeToIncomeAccountMappings, penaltyToIncomeAccountMappings, existingProduct.allowOverdraft,
+                existingProduct.overdraftLimit, existingProduct.minRequiredBalance, existingProduct.enforceMinRequiredBalance,
+                existingProduct.maxAllowedLienLimit, existingProduct.lienAllowed, existingProduct.minBalanceForInterestCalculation,
                 existingProduct.nominalAnnualInterestRateOverdraft, existingProduct.minOverdraftForInterestCalculation,
                 existingProduct.withHoldTax, existingProduct.taxGroup, existingProduct.taxGroupOptions,
                 existingProduct.isDormancyTrackingActive, existingProduct.daysToInactive, existingProduct.daysToDormancy,
@@ -303,6 +313,8 @@ public final class SavingsProductData implements Serializable {
                 existingProduct.floatingInterestRates, existingProduct.withdrawalFrequencyEnum, existingProduct.withdrawalFrequencyOptions,
                 existingProduct.getWithdrawalFrequency(), existingProduct.productCategoryId, existingProduct.productTypeId,
                 existingProduct.productCategories, existingProduct.productTypes);
+        productData.setPostOverdraftInterestOnDeposit(existingProduct.postOverdraftInterestOnDeposit);
+        return productData;
     }
 
     public static SavingsProductData instance(final Long id, final String name, final String shortName, final String description,
@@ -728,5 +740,9 @@ public final class SavingsProductData implements Serializable {
 
     public Integer getWithdrawalFrequency() {
         return withdrawalFrequency;
+    }
+
+    public void setPostOverdraftInterestOnDeposit(boolean postOverdraftInterestOnDeposit) {
+        this.postOverdraftInterestOnDeposit = postOverdraftInterestOnDeposit;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsProductDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsProductDataValidator.java
@@ -49,6 +49,7 @@ import static org.apache.fineract.portfolio.savings.SavingsApiConstants.nominalA
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.numberOfCreditTransactionsParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.numberOfDebitTransactionsParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.overdraftLimitParamName;
+import static org.apache.fineract.portfolio.savings.SavingsApiConstants.postOverdraftInterestOnDepositParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.shortNameParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.taxGroupIdParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.useFloatingInterestRateParamName;
@@ -116,7 +117,8 @@ public class SavingsProductDataValidator {
             numberOfCreditTransactionsParamName, numberOfDebitTransactionsParamName, "receivablePenaltyAccountId",
             "receivableInterestAccountId", "receivableFeeAccountId", "interestPayableAccountId", useFloatingInterestRateParamName,
             floatingInterestRatesParamName, SavingsApiConstants.WITHDRAWAL_FREQUENCY_ENUM, SavingsApiConstants.WITHDRAWAL_FREQUENCY,
-            SavingsApiConstants.savingsProductCategoryIdParamName, SavingsApiConstants.savingsProductTypeIdParamName));
+            SavingsApiConstants.savingsProductCategoryIdParamName, SavingsApiConstants.savingsProductTypeIdParamName,
+            postOverdraftInterestOnDepositParamName));
 
     @Autowired
     public SavingsProductDataValidator(final FromJsonHelper fromApiJsonHelper) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
@@ -32,6 +32,7 @@ import static org.apache.fineract.portfolio.savings.SavingsApiConstants.minOverd
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.minRequiredBalanceParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.nominalAnnualInterestRateOverdraftParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.overdraftLimitParamName;
+import static org.apache.fineract.portfolio.savings.SavingsApiConstants.postOverdraftInterestOnDepositParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.withHoldTaxParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.withdrawalFeeForTransfersParamName;
 
@@ -73,6 +74,7 @@ import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 import javax.persistence.Version;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.codes.domain.CodeValue;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
@@ -287,6 +289,9 @@ public class SavingsAccount extends AbstractPersistableCustom {
 
     @Column(name = "min_overdraft_for_interest_calculation", scale = 6, precision = 19, nullable = true)
     private BigDecimal minOverdraftForInterestCalculation;
+
+    @Column(name = "post_overdraft_interest_on_deposit")
+    private Boolean postOverdraftInterestOnDeposit;
 
     @Column(name = "enforce_min_required_balance")
     private boolean enforceMinRequiredBalance;
@@ -2214,10 +2219,17 @@ public class SavingsAccount extends AbstractPersistableCustom {
             this.minOverdraftForInterestCalculation = newValue;
         }
 
+        if (command.isChangeInBooleanParameterNamed(postOverdraftInterestOnDepositParamName, this.postOverdraftInterestOnDeposit)) {
+            final boolean newValue = command.booleanPrimitiveValueOfParameterNamed(postOverdraftInterestOnDepositParamName);
+            actualChanges.put(postOverdraftInterestOnDepositParamName, newValue);
+            this.postOverdraftInterestOnDeposit = newValue;
+        }
+
         if (!this.allowOverdraft) {
             this.overdraftLimit = null;
             this.nominalAnnualInterestRateOverdraft = null;
             this.minOverdraftForInterestCalculation = null;
+            this.postOverdraftInterestOnDeposit = null;
         }
 
         if (command.isChangeInBooleanParameterNamed(enforceMinRequiredBalanceParamName, this.enforceMinRequiredBalance)) {
@@ -4488,7 +4500,7 @@ public class SavingsAccount extends AbstractPersistableCustom {
         this.accountType = accountType;
     }
 
-    private boolean isOverdraft() {
+    public boolean isOverdraft() {
         return allowOverdraft;
     }
 
@@ -5221,5 +5233,13 @@ public class SavingsAccount extends AbstractPersistableCustom {
 
     public LocalDate getNextFlexWithdrawalDate() {
         return nextFlexWithdrawalDate;
+    }
+
+    public void setPostOverdraftInterestOnDeposit(Boolean postOverdraftInterestOnDeposit) {
+        this.postOverdraftInterestOnDeposit = postOverdraftInterestOnDeposit;
+    }
+
+    public boolean isPostOverdraftInterestOnDeposit() {
+        return ObjectUtils.defaultIfNull(this.postOverdraftInterestOnDeposit, Boolean.FALSE);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
@@ -48,6 +48,7 @@ import static org.apache.fineract.portfolio.savings.SavingsApiConstants.minRequi
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.nominalAnnualInterestRateOverdraftParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.nominalAnnualInterestRateParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.overdraftLimitParamName;
+import static org.apache.fineract.portfolio.savings.SavingsApiConstants.postOverdraftInterestOnDepositParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.productIdParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.submittedOnDateParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.useFloatingInterestRateParamName;
@@ -64,6 +65,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.exception.UnsupportedParameterException;
@@ -303,6 +305,13 @@ public class SavingsAccountAssembler {
             minOverdraftForInterestCalculation = product.minOverdraftForInterestCalculation();
         }
 
+        boolean postOverdraftInterestOnDeposit = false;
+        if (command.parameterExists(postOverdraftInterestOnDepositParamName)) {
+            postOverdraftInterestOnDeposit = command.booleanPrimitiveValueOfParameterNamed(postOverdraftInterestOnDepositParamName);
+        } else {
+            postOverdraftInterestOnDeposit = ObjectUtils.defaultIfNull(product.getPostOverdraftInterestOnDeposit(), Boolean.FALSE);
+        }
+
         boolean enforceMinRequiredBalance = false;
         if (command.parameterExists(enforceMinRequiredBalanceParamName)) {
             enforceMinRequiredBalance = command.booleanPrimitiveValueOfParameterNamed(enforceMinRequiredBalanceParamName);
@@ -361,7 +370,7 @@ public class SavingsAccountAssembler {
         account.validateNewApplicationState(DateUtils.getBusinessLocalDate(), SAVINGS_ACCOUNT_RESOURCE_NAME);
         account.setWithdrawalFrequency(withdrawalFrequency);
         account.setWithdrawalFrequencyEnum(withdrawalFrequencyEnum);
-
+        account.setPostOverdraftInterestOnDeposit(postOverdraftInterestOnDeposit);
         account.validateAccountValuesWithProduct();
 
         return account;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsProduct.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsProduct.java
@@ -53,6 +53,7 @@ import static org.apache.fineract.portfolio.savings.SavingsApiConstants.nominalA
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.numberOfCreditTransactionsParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.numberOfDebitTransactionsParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.overdraftLimitParamName;
+import static org.apache.fineract.portfolio.savings.SavingsApiConstants.postOverdraftInterestOnDepositParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.shortNameParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.taxGroupIdParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.useFloatingInterestRateParamName;
@@ -185,6 +186,9 @@ public class SavingsProduct extends AbstractPersistableCustom {
 
     @Column(name = "min_overdraft_for_interest_calculation", scale = 6, precision = 19, nullable = true)
     private BigDecimal minOverdraftForInterestCalculation;
+
+    @Column(name = "post_overdraft_interest_on_deposit")
+    private Boolean postOverdraftInterestOnDeposit;
 
     @Column(name = "enforce_min_required_balance")
     private boolean enforceMinRequiredBalance;
@@ -604,6 +608,12 @@ public class SavingsProduct extends AbstractPersistableCustom {
             this.overdraftLimit = newValue;
         }
 
+        if (command.isChangeInBooleanParameterNamed(postOverdraftInterestOnDepositParamName, this.postOverdraftInterestOnDeposit)) {
+            final boolean newValue = command.booleanPrimitiveValueOfParameterNamed(postOverdraftInterestOnDepositParamName);
+            actualChanges.put(postOverdraftInterestOnDepositParamName, newValue);
+            this.postOverdraftInterestOnDeposit = newValue;
+        }
+
         if (command.isChangeInBigDecimalParameterNamedDefaultingZeroToNull(nominalAnnualInterestRateOverdraftParamName,
                 this.nominalAnnualInterestRateOverdraft)) {
             final BigDecimal newValue = command
@@ -626,6 +636,7 @@ public class SavingsProduct extends AbstractPersistableCustom {
             this.overdraftLimit = null;
             this.nominalAnnualInterestRateOverdraft = null;
             this.minOverdraftForInterestCalculation = null;
+            this.postOverdraftInterestOnDeposit = null;
         }
 
         if (command.isChangeInBooleanParameterNamed(enforceMinRequiredBalanceParamName, this.enforceMinRequiredBalance)) {
@@ -945,4 +956,11 @@ public class SavingsProduct extends AbstractPersistableCustom {
         this.productType = productType;
     }
 
+    public Boolean getPostOverdraftInterestOnDeposit() {
+        return postOverdraftInterestOnDeposit;
+    }
+
+    public void setPostOverdraftInterestOnDeposit(Boolean postOverdraftInterestOnDeposit) {
+        this.postOverdraftInterestOnDeposit = postOverdraftInterestOnDeposit;
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsProductAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsProductAssembler.java
@@ -53,6 +53,7 @@ import static org.apache.fineract.portfolio.savings.SavingsApiConstants.nominalA
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.numberOfCreditTransactionsParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.numberOfDebitTransactionsParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.overdraftLimitParamName;
+import static org.apache.fineract.portfolio.savings.SavingsApiConstants.postOverdraftInterestOnDepositParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.shortNameParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.taxGroupIdParamName;
 import static org.apache.fineract.portfolio.savings.SavingsApiConstants.useFloatingInterestRateParamName;
@@ -266,13 +267,19 @@ public class SavingsProductAssembler {
             }
         }
 
-        return SavingsProduct.createNew(name, shortName, description, currency, interestRate, interestCompoundingPeriodType,
-                interestPostingPeriodType, interestCalculationType, interestCalculationDaysInYearType, minRequiredOpeningBalance,
-                lockinPeriodFrequency, lockinPeriodFrequencyType, iswithdrawalFeeApplicableForTransfer, accountingRuleType, charges,
-                allowOverdraft, overdraftLimit, enforceMinRequiredBalance, minRequiredBalance, lienAllowed, maxAllowedLienLimit,
-                minBalanceForInterestCalculation, nominalAnnualInterestRateOverdraft, minOverdraftForInterestCalculation, withHoldTax,
-                taxGroup, isDormancyTrackingActive, daysToInactive, daysToDormancy, daysToEscheat, isInterestPostingConfigUpdate,
-                numOfCreditTransaction, numOfDebitTransaction, useFloatingInterestRate, withdrawalFrequency, withdrawalFrequencyEnum);
+        SavingsProduct savingsProduct = SavingsProduct.createNew(name, shortName, description, currency, interestRate,
+                interestCompoundingPeriodType, interestPostingPeriodType, interestCalculationType, interestCalculationDaysInYearType,
+                minRequiredOpeningBalance, lockinPeriodFrequency, lockinPeriodFrequencyType, iswithdrawalFeeApplicableForTransfer,
+                accountingRuleType, charges, allowOverdraft, overdraftLimit, enforceMinRequiredBalance, minRequiredBalance, lienAllowed,
+                maxAllowedLienLimit, minBalanceForInterestCalculation, nominalAnnualInterestRateOverdraft,
+                minOverdraftForInterestCalculation, withHoldTax, taxGroup, isDormancyTrackingActive, daysToInactive, daysToDormancy,
+                daysToEscheat, isInterestPostingConfigUpdate, numOfCreditTransaction, numOfDebitTransaction, useFloatingInterestRate,
+                withdrawalFrequency, withdrawalFrequencyEnum);
+        if (allowOverdraft && command.parameterExists(postOverdraftInterestOnDepositParamName)) {
+            savingsProduct.setPostOverdraftInterestOnDeposit(
+                    command.booleanPrimitiveValueOfParameterNamed(postOverdraftInterestOnDepositParamName));
+        }
+        return savingsProduct;
     }
 
     public Set<SavingsProductFloatingInterestRate> assembleListOfFloatingInterestRates(final JsonCommand command,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/interest/EndOfDayBalance.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/interest/EndOfDayBalance.java
@@ -197,7 +197,7 @@ public class EndOfDayBalance {
         BigDecimal futureValue = presentValue.setScale(9, MoneyHelper.getRoundingMode());
         List<BigDecimal> futureValues = new ArrayList<>();
 
-        if (interestRateAsFraction.compareTo(BigDecimal.ZERO) > 0) {
+        if (interestRateAsFraction.compareTo(BigDecimal.ZERO) > 0 || overdraftInterestRateAsFraction.compareTo(BigDecimal.ZERO) > 0) {
             if (presentValue.compareTo(BigDecimal.ZERO) >= 0) {
                 if (presentValue.compareTo(minBalanceForInterestCalculation) >= 0) {
                     final BigDecimal r = interestRateAsFraction.multiply(multiplicand);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsProductReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsProductReadPlatformServiceImpl.java
@@ -139,7 +139,8 @@ public class SavingsProductReadPlatformServiceImpl implements SavingsProductRead
             sqlBuilder.append("sp.num_of_credit_transaction as numOfCreditTransaction, ");
             sqlBuilder.append("sp.num_of_debit_transaction as numOfDebitTransaction ,");
             sqlBuilder.append("sp.withdrawal_frequency as withdrawalFrequency, ");
-            sqlBuilder.append("sp.withdrawal_frequency_enum as withdrawalFrequencyEnum ");
+            sqlBuilder.append("sp.withdrawal_frequency_enum as withdrawalFrequencyEnum, ");
+            sqlBuilder.append("sp.post_overdraft_interest_on_deposit as postOverdraftInterestOnDeposit ");
             sqlBuilder.append("from m_savings_product sp ");
             sqlBuilder.append("join m_currency curr on curr.code = sp.currency_code ");
             sqlBuilder.append("left join m_tax_group tg on tg.id = sp.tax_group_id  ");
@@ -205,6 +206,7 @@ public class SavingsProductReadPlatformServiceImpl implements SavingsProductRead
             final BigDecimal overdraftLimit = rs.getBigDecimal("overdraftLimit");
             final BigDecimal nominalAnnualInterestRateOverdraft = rs.getBigDecimal("nominalAnnualInterestRateOverdraft");
             final BigDecimal minOverdraftForInterestCalculation = rs.getBigDecimal("minOverdraftForInterestCalculation");
+            final boolean postOverdraftInterestOnDeposit = rs.getBoolean("postOverdraftInterestOnDeposit");
 
             final BigDecimal minRequiredBalance = rs.getBigDecimal("minRequiredBalance");
             final boolean enforceMinRequiredBalance = rs.getBoolean("enforceMinRequiredBalance");
@@ -238,7 +240,7 @@ public class SavingsProductReadPlatformServiceImpl implements SavingsProductRead
                         .withdrawalFrequency(WithdrawalFrequency.fromInt(withdrawalFrequencyEnumValue));
             }
 
-            return SavingsProductData.instance(id, name, shortName, description, currency, nominalAnnualInterestRate,
+            SavingsProductData product = SavingsProductData.instance(id, name, shortName, description, currency, nominalAnnualInterestRate,
                     compoundingInterestPeriodType, interestPostingPeriodType, interestCalculationType, interestCalculationDaysInYearType,
                     minRequiredOpeningBalance, lockinPeriodFrequency, lockinPeriodFrequencyType, withdrawalFeeForTransfers,
                     accountingRuleType, allowOverdraft, overdraftLimit, minRequiredBalance, enforceMinRequiredBalance, maxAllowedLienLimit,
@@ -246,6 +248,8 @@ public class SavingsProductReadPlatformServiceImpl implements SavingsProductRead
                     withHoldTax, taxGroupData, isDormancyTrackingActive, daysToInactive, daysToDormancy, daysToEscheat,
                     isInterestPostingConfigUpdate, numOfCreditTransaction, numOfDebitTransaction, useFloatingInterestRate,
                     withdrawalFrequency, withdrawalFrequencyEnum, productCategoryId, productTypeId);
+            product.setPostOverdraftInterestOnDeposit(postOverdraftInterestOnDeposit);
+            return product;
         }
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsProductWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsProductWritePlatformServiceJpaRepositoryImpl.java
@@ -129,7 +129,7 @@ public class SavingsProductWritePlatformServiceJpaRepositoryImpl implements Savi
             this.fromApiJsonDataValidator.validateForCreate(command.json());
 
             final SavingsProduct product = this.savingsProductAssembler.assemble(command);
-            CodeValue productCategory = getLoanProductCategory(command);
+            CodeValue productCategory = getProductCategory(command);
             if (productCategory != null) {
                 product.setProductCategory(productCategory);
             }
@@ -178,7 +178,7 @@ public class SavingsProductWritePlatformServiceJpaRepositoryImpl implements Savi
             final SavingsProduct product = this.savingProductRepository.findById(productId)
                     .orElseThrow(() -> new SavingsProductNotFoundException(productId));
 
-            CodeValue productCategory = getLoanProductCategory(command);
+            CodeValue productCategory = getProductCategory(command);
             if (productCategory != null) {
                 product.setProductCategory(productCategory);
             }
@@ -308,7 +308,7 @@ public class SavingsProductWritePlatformServiceJpaRepositoryImpl implements Savi
     }
 
     @Nullable
-    private CodeValue getLoanProductCategory(JsonCommand command) {
+    private CodeValue getProductCategory(JsonCommand command) {
         CodeValue productCategory = null;
         final Long productCategoryId = command.longValueOfParameterNamed(SavingsApiConstants.savingsProductCategoryIdParamName);
         if (productCategoryId != null) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsSchedularServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsSchedularServiceImpl.java
@@ -214,7 +214,9 @@ public class SavingsSchedularServiceImpl implements SavingsSchedularService {
                     final SavingsAccount savingAccount = this.savingAccountAssembler.assembleFrom(savingAccountId);
                     savingsAccountNumber = savingAccount.getAccountNumber();
                     checkClientOrGroupActive(savingAccount);
-                    this.savingsAccountWritePlatformService.postInterest(savingAccount, false, jobRunDate);
+                    if (!savingAccount.isPostOverdraftInterestOnDeposit()) {
+                        this.savingsAccountWritePlatformService.postInterest(savingAccount, false, jobRunDate);
+                    }
                     numberOfRetries = maxNumberOfRetries + 1;
                 } catch (CannotAcquireLockException | ObjectOptimisticLockingFailureException exception) {
                     logger.info("Recalulate interest job has been retried  " + numberOfRetries + " time(s)");

--- a/fineract-provider/src/main/resources/db/changelog/custom-changelog/CI18-129_add_enable_overdraft_interest_on_deposit_global_config.xml
+++ b/fineract-provider/src/main/resources/db/changelog/custom-changelog/CI18-129_add_enable_overdraft_interest_on_deposit_global_config.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="frank@fiter.io" id="add_global_configuration_for_post_overdraft_interest_on_deposit">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="1">
+                    SELECT COUNT(1) FROM c_configuration WHERE name = 'post-overdraft-interest-on-deposit'
+                </sqlCheck>
+            </not>
+        </preConditions>
+
+        <insert tableName="c_configuration">
+            <column name="name" value="post-overdraft-interest-on-deposit" />
+            <column name="value" value="0" />
+            <column name="enabled" valueBoolean="0" />
+            <column name="description" value="Allows overdraft interest to be posted each time a deposit is made on an account that is in overdraft. When this is turned on the option to enable this on savings products and accounts will be available." />
+        </insert>
+    </changeSet>
+    <changeSet author="frank@fiter.io" id="add_post_over_draft_interest_on_deposit_to_savings_product">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="m_savings_product" columnName="post_overdraft_interest_on_deposit"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="m_savings_product">
+            <column name="post_overdraft_interest_on_deposit" type="boolean">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet author="frank@fiter.io" id="add_post_over_draft_interest_on_deposit_to_savings_account">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="m_savings_account" columnName="post_overdraft_interest_on_deposit"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="m_savings_account">
+            <column name="post_overdraft_interest_on_deposit" type="boolean">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/custom-changelog/CI18-129_add_enable_overdraft_interest_on_deposit_global_config.xml
+++ b/fineract-provider/src/main/resources/db/changelog/custom-changelog/CI18-129_add_enable_overdraft_interest_on_deposit_global_config.xml
@@ -32,7 +32,7 @@
         <insert tableName="c_configuration">
             <column name="name" value="post-overdraft-interest-on-deposit" />
             <column name="value" value="0" />
-            <column name="enabled" valueBoolean="0" />
+            <column name="enabled" valueBoolean="false" />
             <column name="description" value="Allows overdraft interest to be posted each time a deposit is made on an account that is in overdraft. When this is turned on the option to enable this on savings products and accounts will be available." />
         </insert>
     </changeSet>

--- a/fineract-provider/src/main/resources/db/changelog/custom-changelog/CI18-137_add_max_active_loans_global_config.xml
+++ b/fineract-provider/src/main/resources/db/changelog/custom-changelog/CI18-137_add_max_active_loans_global_config.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="frank@fiter.io" id="add_global_configuration_for_max_active_loans">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="1">
+                    SELECT COUNT(1) FROM c_configuration WHERE name = 'max-active-loans'
+                </sqlCheck>
+            </not>
+        </preConditions>
+
+        <insert tableName="c_configuration">
+            <column name="name" value="max-active-loans" />
+            <column name="value" value="0" />
+            <column name="enabled" valueBoolean="0" />
+            <column name="description" value="Defines the maximum number of active loans a client should have at a time. 0 means unlimited if this config is enabled." />
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/custom-changelog/CI18-137_add_max_active_loans_global_config.xml
+++ b/fineract-provider/src/main/resources/db/changelog/custom-changelog/CI18-137_add_max_active_loans_global_config.xml
@@ -32,7 +32,7 @@
         <insert tableName="c_configuration">
             <column name="name" value="max-active-loans" />
             <column name="value" value="0" />
-            <column name="enabled" valueBoolean="0" />
+            <column name="enabled" valueBoolean="false" />
             <column name="description" value="Defines the maximum number of active loans a client should have at a time. 0 means unlimited if this config is enabled." />
         </insert>
     </changeSet>

--- a/fineract-provider/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/fineract-provider/src/main/resources/db/changelog/db.changelog-master.xml
@@ -29,4 +29,5 @@
     <include file="tenant-store/changelog-tenant-store.xml" relativeToChangelogFile="true" context="tenant_store_db AND !initial_switch"/>
     <include file="tenant/initial-switch-changelog-tenant.xml" relativeToChangelogFile="true" context="tenant_db AND initial_switch"/>
     <include file="tenant/changelog-tenant.xml" relativeToChangelogFile="true" context="tenant_db AND !initial_switch"/>
+    <includeAll path="custom-changelog" relativeToChangelogFile="true" context="tenant_db" />
 </databaseChangeLog>


### PR DESCRIPTION
This PR covers two tickets:
- Modify the Overdraft feature to enable interest posting upon deposit: https://fiterio.atlassian.net/browse/CI18-129
- Adding limits for number of active loans: https://fiterio.atlassian.net/browse/CI18-137

Both these features can be turned on/off via the global configs.

I've also created a folder for all custom migrations so that, going forward, we can put migrations there without having to modify the `db.changelog-master.xml` file.