### PR TITLE
CI18-144: Introduce 28-day interest rate frequency

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/common/domain/PeriodFrequencyType.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/common/domain/PeriodFrequencyType.java
@@ -28,7 +28,7 @@ public enum PeriodFrequencyType {
     MONTHS(2, "periodFrequencyType.months"), //
     YEARS(3, "periodFrequencyType.years"), //
     WHOLE_TERM(4, "periodFrequencyType.whole_term"), //
-    INVALID(5, "periodFrequencyType.invalid");
+    INVALID(5, "periodFrequencyType.invalid"), DAYS_28(6, "periodFrequencyType.days28");
 
     private final Integer value;
     private final String code;
@@ -64,6 +64,9 @@ public enum PeriodFrequencyType {
                 break;
                 case 4:
                     repaymentFrequencyType = PeriodFrequencyType.WHOLE_TERM;
+                break;
+                case 6:
+                    repaymentFrequencyType = PeriodFrequencyType.DAYS_28;
                 break;
             }
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/service/InterestRateChartEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/interestratechart/service/InterestRateChartEnumerations.java
@@ -42,6 +42,7 @@ public final class InterestRateChartEnumerations {
                 PeriodFrequencyType.INVALID.getCode(), "Invalid");
 
         switch (type) {
+            case DAYS_28:
             case INVALID:
             break;
             case DAYS:

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
@@ -4681,6 +4681,7 @@ public class Loan extends AbstractAuditableWithUTCDateTimeCustom {
             break;
             case INVALID:
             break;
+            case DAYS_28:
             case WHOLE_TERM:
             break;
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AprCalculator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AprCalculator.java
@@ -42,6 +42,9 @@ public class AprCalculator {
             case YEARS:
                 defaultAnnualNominalInterestRate = interestRatePerPeriod.multiply(BigDecimal.valueOf(1));
             break;
+            case DAYS_28:
+                defaultAnnualNominalInterestRate = interestRatePerPeriod.multiply(BigDecimal.valueOf(365 / 28));
+            break;
             case WHOLE_TERM:
                 final BigDecimal ratePerPeriod = interestRatePerPeriod.divide(BigDecimal.valueOf(numberOfRepayments * repaymentEvery), 8,
                         RoundingMode.HALF_UP);
@@ -59,6 +62,7 @@ public class AprCalculator {
                     case YEARS:
                         defaultAnnualNominalInterestRate = ratePerPeriod.multiply(BigDecimal.valueOf(1));
                     break;
+                    case DAYS_28:
                     case WHOLE_TERM:
                     break;
                     case INVALID:

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/DefaultPaymentPeriodsInOneYearCalculator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/DefaultPaymentPeriodsInOneYearCalculator.java
@@ -49,6 +49,7 @@ public class DefaultPaymentPeriodsInOneYearCalculator implements PaymentPeriodsI
             case INVALID:
                 paymentPeriodsInOneYear = Integer.valueOf(0);
             break;
+            case DAYS_28:
             case WHOLE_TERM:
                 LOG.error("TODO Implement repaymentFrequencyType for WHOLE_TERM");
             break;
@@ -98,6 +99,7 @@ public class DefaultPaymentPeriodsInOneYearCalculator implements PaymentPeriodsI
             case INVALID:
                 fraction = Double.valueOf("0");
             break;
+            case DAYS_28:
             case WHOLE_TERM:
                 LOG.error("TODO Implement repaymentPeriodFrequencyType for WHOLE_TERM");
             break;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/DefaultScheduledDateGenerator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/DefaultScheduledDateGenerator.java
@@ -248,6 +248,7 @@ public class DefaultScheduledDateGenerator implements ScheduledDateGenerator {
             break;
             case INVALID:
             break;
+            case DAYS_28:
             case WHOLE_TERM:
                 LOG.error("TODO Implement getRepaymentPeriodDate for WHOLE_TERM");
             break;
@@ -290,6 +291,7 @@ public class DefaultScheduledDateGenerator implements ScheduledDateGenerator {
             break;
             case INVALID:
             break;
+            case DAYS_28:
             case WHOLE_TERM:
                 LOG.error("TODO Implement isDateFallsInSchedule for WHOLE_TERM");
             break;
@@ -327,6 +329,7 @@ public class DefaultScheduledDateGenerator implements ScheduledDateGenerator {
             break;
             case INVALID:
             break;
+            case DAYS_28:
             case WHOLE_TERM:
                 LOG.error("TODO Implement repaymentPeriodFrequencyType for WHOLE_TERM");
             break;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
@@ -687,6 +687,7 @@ public final class LoanApplicationTerms {
             break;
             case INVALID:
             break;
+            case DAYS_28:
             case WHOLE_TERM:
                 log.error("TODO Implement getPeriodEndDate for WHOLE_TERM");
             break;
@@ -1092,6 +1093,7 @@ public final class LoanApplicationTerms {
                         }
                         periodicInterestRate = oneDayOfYearInterestRate.multiply(numberOfDaysInPeriod, mc);
                     break;
+                    case DAYS_28:
                     case WHOLE_TERM:
                         log.error("TODO Implement periodicInterestRate for WHOLE_TERM");
                     break;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
@@ -508,7 +508,8 @@ public final class LoanProductDataValidator {
 
             final Integer interestRateFrequencyType = this.fromApiJsonHelper.extractIntegerNamed("interestRateFrequencyType", element,
                     Locale.getDefault());
-            baseDataValidator.reset().parameter("interestRateFrequencyType").value(interestRateFrequencyType).notNull().inMinMaxRange(0, 4);
+            baseDataValidator.reset().parameter("interestRateFrequencyType").value(interestRateFrequencyType).notNull()
+                    .isOneOfTheseValues(0, 1, 2, 3, 4, 6);
         }
 
         // Guarantee Funds
@@ -1414,7 +1415,8 @@ public final class LoanProductDataValidator {
                 interestRateFrequencyType = this.fromApiJsonHelper.extractIntegerNamed("interestRateFrequencyType", element,
                         Locale.getDefault());
             }
-            baseDataValidator.reset().parameter("interestRateFrequencyType").value(interestRateFrequencyType).notNull().inMinMaxRange(0, 4);
+            baseDataValidator.reset().parameter("interestRateFrequencyType").value(interestRateFrequencyType).notNull()
+                    .isOneOfTheseValues(0, 1, 2, 3, 4, 6);
         }
 
         // Guarantee Funds

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanDropdownReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanDropdownReadPlatformServiceImpl.java
@@ -130,9 +130,10 @@ public class LoanDropdownReadPlatformServiceImpl implements LoanDropdownReadPlat
 
     @Override
     public List<EnumOptionData> retrieveInterestRateFrequencyTypeOptions() {
-        // support for monthly and annual percentage rate (MPR) and (APR)
+        // support for 28-day, monthly and annual percentage rate (MPR) and (APR)
         final List<EnumOptionData> interestRateFrequencyTypeOptions = Arrays.asList(interestRateFrequencyType(PeriodFrequencyType.MONTHS),
-                interestRateFrequencyType(PeriodFrequencyType.YEARS), interestRateFrequencyType(PeriodFrequencyType.WHOLE_TERM));
+                interestRateFrequencyType(PeriodFrequencyType.YEARS), interestRateFrequencyType(PeriodFrequencyType.WHOLE_TERM),
+                interestRateFrequencyType(PeriodFrequencyType.DAYS_28));
         return interestRateFrequencyTypeOptions;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanEnumerations.java
@@ -253,6 +253,10 @@ public final class LoanEnumerations {
                 optionData = new EnumOptionData(PeriodFrequencyType.WHOLE_TERM.getValue().longValue(),
                         codePrefix + PeriodFrequencyType.WHOLE_TERM.getCode(), "Whole term");
             break;
+            case DAYS_28:
+                optionData = new EnumOptionData(PeriodFrequencyType.DAYS_28.getValue().longValue(),
+                        codePrefix + PeriodFrequencyType.DAYS_28.getCode(), "Per 28 days");
+            break;
             default:
                 optionData = new EnumOptionData(PeriodFrequencyType.INVALID.getValue().longValue(), PeriodFrequencyType.INVALID.getCode(),
                         "Invalid");

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/DepositAccountUtils.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/DepositAccountUtils.java
@@ -54,6 +54,7 @@ public final class DepositAccountUtils {
             break;
             case INVALID:
             break;
+            case DAYS_28:
             case WHOLE_TERM:
                 LOG.error("TODO Implement calculateNextDepositDate for WHOLE_TERM");
             break;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
@@ -3514,6 +3514,7 @@ public class SavingsAccount extends AbstractPersistableCustom {
             case YEARS:
                 lockedInUntilLocalDate = activationLocalDate.plusYears(this.lockinPeriodFrequency);
             break;
+            case DAYS_28:
             case WHOLE_TERM:
                 LOG.error("TODO Implement calculateDateAccountIsLockedUntil for WHOLE_TERM");
             break;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/serialization/ShareAccountDataSerializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/serialization/ShareAccountDataSerializer.java
@@ -970,6 +970,7 @@ public class ShareAccountDataSerializer {
                 case YEARS:
                     lockinDate = purchaseDate.plusYears(lockinPeriod);
                 break;
+                case DAYS_28:
                 case WHOLE_TERM: // Never comes in to this state.
                 break;
             }


### PR DESCRIPTION
This change introduces an option for 28-day interest rate. This is solely for interest rate calculation and shouldn't affect much else. A number of switch statements have been modified to accommodate the new option but it's mostly added as a redundant case.