### PR TITLE
OXY-260 failure to reschedule Loan Account.

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentReminderRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentReminderRepository.java
@@ -29,4 +29,7 @@ public interface LoanRepaymentReminderRepository
 
     @Query("SELECT r FROM LoanRepaymentReminder r WHERE r.batchId = :batchId")
     List<LoanRepaymentReminder> getLoanRepaymentReminderByBatchId(@Param("batchId") String batchId);
+
+    @Query("SELECT r FROM LoanRepaymentReminder r WHERE r.loanId = :loanId")
+    List<LoanRepaymentReminder> getLoanRepaymentReminderByLoanId(@Param("loanId") Integer loanId);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.fineract.accounting.journalentry.service.JournalEntryWritePlatformService;
 import org.apache.fineract.infrastructure.codes.domain.CodeValue;
 import org.apache.fineract.infrastructure.codes.domain.CodeValueRepositoryWrapper;
@@ -565,8 +566,9 @@ public class LoanRescheduleRequestWritePlatformServiceImpl implements LoanResche
         // delete dependencies on m_loan_repayment_reminder associated with this Loan Account
         List<LoanRepaymentReminder> loanRepaymentReminders = loanRepaymentReminderRepository
                 .getLoanRepaymentReminderByLoanId(loan.getId().intValue());
-        for (LoanRepaymentReminder reminder : loanRepaymentReminders) {
-            loanRepaymentReminderRepository.delete(reminder);
+
+        if (!CollectionUtils.isEmpty(loanRepaymentReminders)) {
+            loanRepaymentReminderRepository.deleteAll(loanRepaymentReminders);
         }
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
@@ -176,6 +176,8 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanInstallmentCharge;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanInterestRecalcualtionAdditionalDetails;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanLifecycleStateMachine;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanOverdueInstallmentCharge;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentReminder;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentReminderRepository;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleTransactionProcessorFactory;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
@@ -279,6 +281,7 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
     private final LoanRepository loanRepository;
     private final RepaymentWithPostDatedChecksAssembler repaymentWithPostDatedChecksAssembler;
     private final PostDatedChecksRepository postDatedChecksRepository;
+    private final LoanRepaymentReminderRepository loanRepaymentReminderRepository;
 
     @Autowired
     private ActiveMqNotificationDomainServiceImpl activeMqNotificationDomainService;
@@ -1917,7 +1920,7 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
                 accruedCharge = accruedCharge.plus(chargePaidByData.getAmount());
             }
         }
-
+        deleteLoanRepaymentRemindersAssociatedToThisLoanAccount(loan);
         final LoanTransaction waiveTransaction = loan.waiveLoanCharge(loanCharge, defaultLoanLifecycleStateMachine(), changes,
                 existingTransactionIds, existingReversedTransactionIds, loanInstallmentNumber, scheduleGeneratorDTO, accruedCharge);
 
@@ -3473,6 +3476,16 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
 
         }
 
+    }
+
+    private void deleteLoanRepaymentRemindersAssociatedToThisLoanAccount(Loan loan) {
+        // delete dependencies on m_loan_repayment_reminder associated with this Loan Account
+        List<LoanRepaymentReminder> loanRepaymentReminders = loanRepaymentReminderRepository
+                .getLoanRepaymentReminderByLoanId(loan.getId().intValue());
+
+        if (!CollectionUtils.isEmpty(loanRepaymentReminders)) {
+            loanRepaymentReminderRepository.deleteAll(loanRepaymentReminders);
+        }
     }
 
 }


### PR DESCRIPTION
When rescheduling the Loan Account, New Repayment schedule is generated and old one is delete. So M_loan_repayment_reminder was blocking the operation since it had stored some loan account/s due to delete restriction

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
