### PR TITLE
CI18-345: Skip loan overdue amount validation during withdrawal

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
@@ -533,7 +533,7 @@ public class SavingsAccountAssembler {
     public SavingsAccount assembleWithMinimalTransactions(final Long savingsId) {
         final SavingsAccount account = this.savingsAccountRepository.findOneWithNotFoundDetection(savingsId);
         // Retrieve 100 most recent active transactions for an account
-        String sql = "SELECT t.id FROM (SELECT * FROM m_savings_account_transaction WHERE savings_account_id = ? AND is_reversed = false ORDER BY id DESC LIMIT 100) t ORDER BY transaction_date, created_date, id;";
+        String sql = "SELECT t.id FROM (SELECT * FROM m_savings_account_transaction WHERE savings_account_id = ? AND is_reversed = false ORDER BY id DESC LIMIT 10) t ORDER BY transaction_date, created_date, id;";
         List<Long> transactionIds = this.jdbcTemplate.queryForList(sql, Long.class, savingsId);
         List<SavingsAccountTransaction> transactions = new ArrayList<>();
         if (!transactionIds.isEmpty()) {


### PR DESCRIPTION
CI18-345: Skip loan overdue amount validation during withdrawal:

Making this change for carbon only, but ultimately all clients who want this performance improvement will have to do without this validation. We can come back at a later stage and implement it in a more efficient fashion. We don't need to iterate through all transactions to determine if a transaction will go into negatives when the overdue loan amount is factored in.
