### PR TITLE
INKO-411 Bulk import infrastructure fix.

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
 import java.net.URLConnection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -243,7 +244,8 @@ public class BulkImportWorkbookServiceImpl implements BulkImportWorkbookService 
         this.securityContext.authenticatedUser();
         final ImportTemplateLocationMapper importTemplateLocationMapper = new ImportTemplateLocationMapper();
         final String sql = "select " + importTemplateLocationMapper.schema();
-        DocumentData documentData = this.jdbcTemplate.queryForObject(sql, importTemplateLocationMapper, new Object[] { importDocumentId }); // NOSONAR
+        DocumentData documentData = this.jdbcTemplate.queryForObject(sql, importTemplateLocationMapper,
+                new Object[] { new BigInteger(importDocumentId) }); // NOSONAR
         return buildResponse(documentData);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
@@ -49,8 +49,6 @@ import org.apache.fineract.infrastructure.documentmanagement.service.DocumentWri
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.tika.Tika;
-import org.apache.tika.io.TikaInputStream;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,17 +91,7 @@ public class BulkImportWorkbookServiceImpl implements BulkImportWorkbookService 
                 final byte[] bytes = baos.toByteArray();
                 InputStream clonedInputStream = new ByteArrayInputStream(bytes);
                 final BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(bytes));
-                final Tika tika = new Tika();
-                final TikaInputStream tikaInputStream = TikaInputStream.get(bis);
-                final String fileType = tika.detect(tikaInputStream);
-                if (!fileType.contains("msoffice") && !fileType.contains("application/vnd.ms-excel")) {
-                    // We had a problem where we tried to upload the downloaded
-                    // file from the import options, it was somehow changed the
-                    // extension we use this fix.
-                    throw new GeneralPlatformDomainRuleException("error.msg.invalid.file.extension",
-                            "Uploaded file extension is not recognized.");
 
-                }
                 Workbook workbook = new HSSFWorkbook(clonedInputStream);
                 GlobalEntityType entityType = null;
                 int primaryColumn = 0;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/contentrepository/FileSystemContentPathSanitizer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/documentmanagement/contentrepository/FileSystemContentPathSanitizer.java
@@ -29,10 +29,6 @@ import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.documentmanagement.exception.ContentManagementException;
 import org.apache.tika.Tika;
-import org.apache.tika.io.TikaInputStream;
-import org.apache.tika.metadata.Metadata;
-import org.apache.tika.parser.AutoDetectParser;
-import org.apache.tika.sax.BodyContentHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,7 +96,7 @@ public class FileSystemContentPathSanitizer implements ContentPathSanitizer {
                             String.format("Detected mime type %s for filename %s not allowed!", extensionMimeType, fileName));
                 }
 
-                String contentMimeType = detectContentMimeType(is);
+                String contentMimeType = extensionMimeType;
 
                 if (StringUtils.isEmpty(contentMimeType)) {
                     throw new RuntimeException(String.format("Could not detect content mime type for %s!", fileName));
@@ -129,16 +125,5 @@ public class FileSystemContentPathSanitizer implements ContentPathSanitizer {
         } catch (Exception e) {
             throw new ContentManagementException(path, e.getMessage(), e);
         }
-    }
-
-    private String detectContentMimeType(BufferedInputStream bis) throws Exception {
-        TikaInputStream tis = TikaInputStream.get(bis);
-        AutoDetectParser parser = new AutoDetectParser();
-        // NOTE: turn off write limit with "-1"
-        BodyContentHandler handler = new BodyContentHandler(-1);
-        Metadata metadata = new Metadata();
-        parser.parse(tis, handler, metadata);
-
-        return metadata.get("Content-Type");
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/CrbKenyaMetropolRequestData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/CrbKenyaMetropolRequestData.java
@@ -55,8 +55,7 @@ public class CrbKenyaMetropolRequestData {
     private String createdOn;
     private MetropolCrbCreditInfoEnchancedData metropolCrbCreditInfoEnchancedData;
 
-    public CrbKenyaMetropolRequestData() {
-    }
+    public CrbKenyaMetropolRequestData() {}
 
     public CrbKenyaMetropolRequestData(Integer report_type, String identity_number, String identity_type) {
         this.report_type = report_type;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/MetropolCrbReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/MetropolCrbReadPlatformServiceImpl.java
@@ -38,10 +38,10 @@ public class MetropolCrbReadPlatformServiceImpl implements MetropolCrbReadPlatfo
 
     @Override
     public CrbKenyaMetropolRequestData fetchIdentityVerificationDetails(Integer loanId) {
-        try{
-        final IdentityVerificationCreditMapper mapper = new IdentityVerificationCreditMapper();
-        final String sql = "SELECT " + mapper.schema() + " order by idty.id DESC LIMIT 1 ";
-        return this.jdbcTemplate.queryForObject(sql, mapper, new Object[] { loanId });
+        try {
+            final IdentityVerificationCreditMapper mapper = new IdentityVerificationCreditMapper();
+            final String sql = "SELECT " + mapper.schema() + " order by idty.id DESC LIMIT 1 ";
+            return this.jdbcTemplate.queryForObject(sql, mapper, new Object[] { loanId });
         } catch (final EmptyResultDataAccessException e) {
             return new CrbKenyaMetropolRequestData();
         }


### PR DESCRIPTION
Tika Library (2.6.0) is incompatible with Apache Poi (4.1.2) downgrade of apache poi happened because pentaho report export was failing

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
