### PR TITLE
FSCAR-50: Add mavenCentral to build.gradle to fetch missing plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,9 @@ buildscript {
         npmRepository = 'https://npm.pkg.github.com'
     }
     repositories {
-        maven { url 'https://plugins.gradle.org/m2/' }
+        mavenCentral()
+        jcenter()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {


### PR DESCRIPTION
FSCAR-50: Add mavenCentral to build.gradle to fetch missing plugins