### PR TITLE
Fix flat interest on reschedule

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
@@ -1645,6 +1645,10 @@ public final class LoanApplicationTerms {
         }
     }
 
+    public BigDecimal getNominalInterestRatePerPeriod() {
+        return this.interestRatePerPeriod;
+    }
+
     public BigDecimal getAnnualNominalInterestRate() {
         return this.annualNominalInterestRate;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanReschedulePreviewPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanReschedulePreviewPlatformServiceImpl.java
@@ -20,11 +20,14 @@ package org.apache.fineract.portfolio.loanaccount.rescheduleloan.service;
 
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
+import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.portfolio.loanaccount.data.LoanTermVariationsData;
 import org.apache.fineract.portfolio.loanaccount.data.ScheduleGeneratorDTO;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
@@ -40,6 +43,8 @@ import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanApplica
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleGenerator;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleGeneratorFactory;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModel;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelPeriod;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelRepaymentPeriod;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequest;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.domain.LoanRescheduleRequestRepositoryWrapper;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.exception.LoanRescheduleRequestNotFoundException;
@@ -140,7 +145,34 @@ public class LoanReschedulePreviewPlatformServiceImpl implements LoanRescheduleP
         LoanScheduleModel loanScheduleModels = LoanScheduleModel.withLoanScheduleModelPeriods(loanScheduleModel.getPeriods(),
                 loanScheduleModel);
 
+        if (loanApplicationTerms.getInterestMethod().isFlat()
+                && isRepaymentExtension(loanRescheduleRequest)) {
+            adjustFlatInterestForExtension(loanScheduleModels, loanApplicationTerms, rescheduleFromDate);
+        }
+
         return loanScheduleModels;
+    }
+
+    private boolean isRepaymentExtension(LoanRescheduleRequest loanRescheduleRequest) {
+        return loanRescheduleRequest.getLoanRescheduleRequestToTermVariationMappings().stream()
+                .anyMatch(m -> m.getLoanTermVariations().getTermType().isExtendRepaymentPeriod());
+    }
+
+    private void adjustFlatInterestForExtension(LoanScheduleModel loanScheduleModel, LoanApplicationTerms terms,
+            LocalDate fromDate) {
+        Money interestPerInstallment = terms.getPrincipal()
+                .percentageOf(terms.getNominalInterestRatePerPeriod(), MoneyHelper.getRoundingMode());
+
+        for (LoanScheduleModelPeriod period : loanScheduleModel.getPeriods()) {
+            if (period.isRepaymentPeriod() && !period.periodDueDate().isBefore(fromDate)) {
+                LoanScheduleModelRepaymentPeriod rp = (LoanScheduleModelRepaymentPeriod) period;
+                MonetaryCurrency currency = terms.getCurrency();
+                BigDecimal current = rp.interestDue() == null ? BigDecimal.ZERO : rp.interestDue();
+                Money currentInterest = Money.of(currency, current);
+                Money difference = interestPerInstallment.minus(currentInterest);
+                rp.addInterestAmount(difference);
+            }
+        }
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/rescheduleloan/service/LoanRescheduleRequestWritePlatformServiceImpl.java
@@ -47,6 +47,7 @@ import org.apache.fineract.organisation.monetary.domain.ApplicationCurrency;
 import org.apache.fineract.organisation.monetary.domain.ApplicationCurrencyRepositoryWrapper;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.portfolio.account.service.AccountTransfersWritePlatformService;
 import org.apache.fineract.portfolio.loanaccount.data.LoanTermVariationsData;
 import org.apache.fineract.portfolio.loanaccount.data.ScheduleGeneratorDTO;
@@ -75,6 +76,9 @@ import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanRepayme
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanRepaymentScheduleHistoryRepository;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleGenerator;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleGeneratorFactory;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModel;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelPeriod;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelRepaymentPeriod;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.service.LoanScheduleHistoryWritePlatformService;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.RescheduleLoansApiConstants;
 import org.apache.fineract.portfolio.loanaccount.rescheduleloan.data.LoanRescheduleRequestDataValidator;
@@ -522,6 +526,11 @@ public class LoanRescheduleRequestWritePlatformServiceImpl implements LoanResche
             final LoanScheduleDTO loanSchedule = loanScheduleGenerator.rescheduleNextInstallments(mathContext, loanApplicationTerms, loan,
                     loanApplicationTerms.getHolidayDetailDTO(), loanRepaymentScheduleTransactionProcessor, rescheduleFromDate);
 
+            if (loanApplicationTerms.getInterestMethod().isFlat() && isRepaymentExtension(loanRescheduleRequest)) {
+                adjustFlatInterestForExtension(loanSchedule.getLoanScheduleModel(), loanSchedule.getInstallments(),
+                        loanApplicationTerms, rescheduleFromDate);
+            }
+
             loan.updateLoanSchedule(loanSchedule.getInstallments());
             loan.recalculateAllCharges();
             ChangedTransactionDetail changedTransactionDetail = loan.processTransactions();
@@ -603,6 +612,34 @@ public class LoanRescheduleRequestWritePlatformServiceImpl implements LoanResche
         final Map<String, Object> accountingBridgeData = loan.deriveAccountingBridgeData(applicationCurrency.toData(),
                 existingTransactionIds, existingReversedTransactionIds, isAccountTransfer);
         this.journalEntryWritePlatformService.createJournalEntriesForLoan(accountingBridgeData);
+    }
+
+    private boolean isRepaymentExtension(LoanRescheduleRequest loanRescheduleRequest) {
+        return loanRescheduleRequest.getLoanRescheduleRequestToTermVariationMappings().stream()
+                .anyMatch(m -> m.getLoanTermVariations().getTermType().isExtendRepaymentPeriod());
+    }
+
+    private void adjustFlatInterestForExtension(LoanScheduleModel loanScheduleModel,
+            List<LoanRepaymentScheduleInstallment> installments, LoanApplicationTerms terms, LocalDate fromDate) {
+        Money interestPerInstallment = terms.getPrincipal()
+                .percentageOf(terms.getNominalInterestRatePerPeriod(), MoneyHelper.getRoundingMode());
+        MonetaryCurrency currency = terms.getCurrency();
+
+        for (LoanScheduleModelPeriod period : loanScheduleModel.getPeriods()) {
+            if (period.isRepaymentPeriod() && !period.periodDueDate().isBefore(fromDate)) {
+                LoanScheduleModelRepaymentPeriod rp = (LoanScheduleModelRepaymentPeriod) period;
+                BigDecimal current = rp.interestDue() == null ? BigDecimal.ZERO : rp.interestDue();
+                Money currentInterest = Money.of(currency, current);
+                Money diff = interestPerInstallment.minus(currentInterest);
+                rp.addInterestAmount(diff);
+            }
+        }
+
+        for (LoanRepaymentScheduleInstallment installment : installments) {
+            if (!installment.getDueDate().isBefore(fromDate)) {
+                installment.updateInterestCharged(interestPerInstallment.getAmount());
+            }
+        }
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/InterestMethod.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/InterestMethod.java
@@ -58,4 +58,8 @@ public enum InterestMethod {
     public boolean isDecliningBalnce() {
         return this.value.equals(InterestMethod.DECLINING_BALANCE.getValue());
     }
+
+    public boolean isFlat() {
+        return this.value.equals(InterestMethod.FLAT.getValue());
+    }
 }


### PR DESCRIPTION
## Summary
- ensure flat interest remains constant when extending schedules
- detect repayment extension requests
- adjust preview and apply services to set fixed interest

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68550cd86974832ca6c8415e1d41acfc