### PR TITLE
Remove deprecated insecure HTTP client configuration and enforce TLS validation

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/processor/ProcessorHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/hooks/processor/ProcessorHelper.java
@@ -18,16 +18,6 @@
  */
 package org.apache.fineract.infrastructure.hooks.processor;
 
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-import lombok.RequiredArgsConstructor;
 import okhttp3.OkHttpClient;
 import org.apache.fineract.infrastructure.configuration.service.ExternalServiceHelper;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
@@ -41,7 +31,6 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 @Service
-@RequiredArgsConstructor
 public final class ProcessorHelper {
 
     // Nota bene: Similar code to insecure HTTPS is also in Fineract Client's
@@ -51,37 +40,14 @@ public final class ProcessorHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProcessorHelper.class);
 
-    @SuppressWarnings("unused")
-    private static final X509TrustManager insecureX509TrustManager = new X509TrustManager() {
-
-        @Override
-        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {}// NOSONAR
-
-        @Override
-        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {}// NOSONAR
-
-        @Override
-        public X509Certificate[] getAcceptedIssuers() {
-            return new X509Certificate[] {};
-        }
-    };
-
     /**
-     * Configure HTTP client to be "insecure", as in skipping host SSL certificate verification. While this can be
-     * useful during development e.g. when using self-signed certificates, it should never be enabled in production (due
-     * to "man in the middle").
+     * Deprecated insecure HTTP client switch. Kept only for backward compatibility; TLS validation is always enforced.
      */
     private final boolean insecureHttpClient = Boolean.getBoolean("fineract.insecureHttpClient");
-    private final SSLContext insecureSSLContext;
 
     @Autowired
-    public ProcessorHelper(FineractProperties fineractProperties) throws KeyManagementException, NoSuchAlgorithmException {
+    public ProcessorHelper(FineractProperties fineractProperties) {
         this.fineractProperties = fineractProperties;
-        if (insecureHttpClient) {
-            insecureSSLContext = createInsecureSSLContext();
-        } else {
-            insecureSSLContext = null;
-        }
     }
 
     private OkHttpClient createClient() {
@@ -93,16 +59,7 @@ public final class ProcessorHelper {
     }
 
     private void configureInsecureClient(final OkHttpClient.Builder okBuilder) {
-        okBuilder.sslSocketFactory(insecureSSLContext.getSocketFactory(), insecureX509TrustManager);
-        HostnameVerifier insecureHostnameVerifier = (hostname, session) -> true;// NOSONAR
-        okBuilder.hostnameVerifier(insecureHostnameVerifier);
-    }
-
-    private SSLContext createInsecureSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
-        SSLContext insecureSSLContext = SSLContext.getInstance("TLS"); // TODO "TLS" or "SSL" as in
-        // FineractClient.Builder?
-        insecureSSLContext.init(null, new TrustManager[] { insecureX509TrustManager }, new SecureRandom());
-        return insecureSSLContext;
+        LOG.warn("Ignoring `fineract.insecureHttpClient=true`: insecure TLS settings are disabled; using default secure TLS validation.");
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
This pull request removes support for insecure HTTP client configurations in the `ProcessorHelper` class, ensuring that TLS validation is always enforced. The changes deprecate the ability to disable SSL certificate verification, improving security and reducing technical debt related to legacy insecure options.

Security improvements:

* Removed all code related to the `insecureHttpClient` option, including the custom `X509TrustManager`, `SSLContext`, and logic for skipping SSL certificate verification. TLS validation is now always enforced. [[1]](diffhunk://#diff-1d795f6e046aa3b856186409a7330109723169f9eade25374ba76efe23acdec9L21-L30) [[2]](diffhunk://#diff-1d795f6e046aa3b856186409a7330109723169f9eade25374ba76efe23acdec9L44) [[3]](diffhunk://#diff-1d795f6e046aa3b856186409a7330109723169f9eade25374ba76efe23acdec9L54-L84)
* Updated the `configureInsecureClient` method to only log a warning if the insecure option is set, rather than actually disabling TLS validation.

Code cleanup:

* Removed unnecessary imports and the `@RequiredArgsConstructor` annotation from `ProcessorHelper`, as well as the now-unused fields and methods related to insecure TLS handling. [[1]](diffhunk://#diff-1d795f6e046aa3b856186409a7330109723169f9eade25374ba76efe23acdec9L21-L30) [[2]](diffhunk://#diff-1d795f6e046aa3b856186409a7330109723169f9eade25374ba76efe23acdec9L44) [[3]](diffhunk://#diff-1d795f6e046aa3b856186409a7330109723169f9eade25374ba76efe23acdec9L54-L84)