### PR TITLE
Implement input sanitization for API links to prevent scriptable and absolute URLs

### DIFF
--- a/fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm
+++ b/fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm
@@ -29,7 +29,29 @@
 	baseURL = "";
 	defQueryParams = "tenantIdentifier=default&pretty=true";
 
+	function sanitizeApiLink(apiLink) {
+		if (!apiLink) {
+			return null;
+		}
+		var link = $.trim(apiLink);
+		var lower = link.toLowerCase();
+
+		// Prevent scriptable/absolute URLs; this page should only navigate to relative API paths.
+		if (lower.indexOf("javascript:") === 0 || lower.indexOf("data:") === 0
+				|| lower.indexOf("vbscript:") === 0 || lower.indexOf("//") === 0
+				|| lower.indexOf("http://") === 0 || lower.indexOf("https://") === 0) {
+			return null;
+		}
+
+		return link;
+	}
+
 	function clickAPILink(apiLink) {
+
+	    apiLink = sanitizeApiLink(apiLink);
+		if (!apiLink)
+			return;
+
 		var currentLink = baseURL + apiLink;
 		if (apiLink.indexOf("?") < 0)
 			currentLink += "?" + defQueryParams;
@@ -46,6 +68,10 @@
 	}
 
 	function clickAPILinkNotPretty(apiLink) {
+	    apiLink = sanitizeApiLink(apiLink);
+		if (!apiLink)
+			return;
+
 		var fixedQueryParams = "tenantIdentifier=default";
 		var currentLink = baseURL + apiLink;
 		if (apiLink.indexOf("?") < 0)


### PR DESCRIPTION
This pull request improves the security of the legacy API documentation page by sanitizing API links before navigation. The main change is the introduction of a function to prevent navigation to potentially dangerous or unintended URLs.

Security enhancements:

* Added a `sanitizeApiLink` function to ensure that only relative API paths are allowed, blocking scriptable and absolute URLs such as those starting with `javascript:`, `data:`, `vbscript:`, `//`, `http://`, or `https://`. This helps prevent XSS and other injection attacks. (`fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm`)
* Updated the `clickAPILink` and `clickAPILinkNotPretty` functions to use `sanitizeApiLink`, ensuring all API link navigations are validated before proceeding. (`fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm`) [[1]](diffhunk://#diff-211266e206515b7ec17e5de2cdf2f5375ca5385abe2bdb248d537f07332e67beR32-R54) [[2]](diffhunk://#diff-211266e206515b7ec17e5de2cdf2f5375ca5385abe2bdb248d537f07332e67beR71-R74)


https://fiterio.atlassian.net/browse/FSO-390
https://fiterio.atlassian.net/browse/FSO-391