### PR TITLE
Validate orderBy and sortOrder inputs against allowlists in SearchParameters

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/SearchParameters.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/service/SearchParameters.java
@@ -121,8 +121,10 @@ public final class SearchParameters {
         final Long staffId = null;
         final Boolean orphansOnly = false;
         final boolean isSelfUser = false;
+        final String safeOrderBy = getAllowedJournalEntryOrderBy(orderBy);
+        final String safeSortOrder = getAllowedSortOrder(sortOrder);
 
-        return new SearchParameters(null, officeId, null, null, null, null, null, offset, maxLimitAllowed, orderBy, sortOrder, staffId,
+        return new SearchParameters(null, officeId, null, null, null, null, null, offset, maxLimitAllowed, safeOrderBy, safeSortOrder, staffId,
                 null, loanId, savingsId, orphansOnly, isSelfUser);
     }
 
@@ -131,8 +133,10 @@ public final class SearchParameters {
         final Integer maxLimitAllowed = getCheckedLimit(limit);
         final Long staffId = null;
         final Boolean orphansOnly = false;
+        final String safeOrderBy = getAllowedJournalEntryOrderBy(orderBy);
+        final String safeSortOrder = getAllowedSortOrder(sortOrder);
 
-        return new SearchParameters(null, officeId, null, null, null, null, null, offset, maxLimitAllowed, orderBy, sortOrder, staffId,
+        return new SearchParameters(null, officeId, null, null, null, null, null, offset, maxLimitAllowed, safeOrderBy, safeSortOrder, staffId,
                 null, loanId, savingsId, orphansOnly, currencyCode);
     }
 
@@ -578,5 +582,38 @@ public final class SearchParameters {
 
     public String getClientType() {
         return clientType;
+    }
+
+    /**
+     * Validates and returns the orderBy column for journal entries against an allowlist.
+     * Returns null if the input is blank or not in the allowlist.
+     */
+    private static String getAllowedJournalEntryOrderBy(final String orderBy) {
+        if (StringUtils.isBlank(orderBy)) {
+            return null;
+        }
+        final String normalized = StringUtils.trim(orderBy);
+        if ("journalEntry.id".equals(normalized) || "journalEntry.entry_date".equals(normalized)
+                || "journalEntry.transaction_id".equals(normalized) || "journalEntry.office_id".equals(normalized)
+                || "journalEntry.gl_account_id".equals(normalized) || "journalEntry.amount".equals(normalized)
+                || "journalEntry.created_date".equals(normalized)) {
+            return normalized;
+        }
+        return null;
+    }
+
+    /**
+     * Validates and returns the sortOrder against an allowlist (ASC/DESC only).
+     * Returns null if the input is blank or not in the allowlist.
+     */
+    private static String getAllowedSortOrder(final String sortOrder) {
+        if (StringUtils.isBlank(sortOrder)) {
+            return null;
+        }
+        final String normalized = StringUtils.upperCase(StringUtils.trim(sortOrder));
+        if ("ASC".equals(normalized) || "DESC".equals(normalized)) {
+            return normalized;
+        }
+        return null;
     }
 }


### PR DESCRIPTION

https://fiterio.atlassian.net/browse/FSO-395

This pull request introduces input validation for the `orderBy` and `sortOrder` parameters in the `SearchParameters` class, specifically for journal entry queries. The main goal is to prevent the use of invalid or unsafe values by restricting them to a predefined allowlist. This helps improve security and data integrity when constructing queries for journal entries.

**Input validation for query parameters:**

* Added private static methods `getAllowedJournalEntryOrderBy` and `getAllowedSortOrder` to validate the `orderBy` and `sortOrder` parameters against an allowlist of accepted values, returning `null` if the input is blank or not allowed.

* Updated the `forJournalEntries` factory methods to use these new validation methods, ensuring only safe values are passed to the `SearchParameters` constructor for `orderBy` and `sortOrder`. [[1]](diffhunk://#diff-ee02739c2248f86e1bf61a112644388d0074861507ea34aef8e495e60b97428aR124-R127) [[2]](diffhunk://#diff-ee02739c2248f86e1bf61a112644388d0074861507ea34aef8e495e60b97428aR136-R139)