### PR TITLE
Add support for transaction notes and external references in bulk import savings account transactions

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/TransactionConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/constants/TransactionConstants.java
@@ -38,14 +38,15 @@ public final class TransactionConstants {
     public static final int RECEIPT_NO_COL = 11;
     public static final int BANK_NO_COL = 12;
     public static final int TRANSACTION_REFERENCE_COL = 13;
-    public static final int STATUS_COL = 14;
-    public static final int FAILURE_REPORT_COL = 15;
-    public static final int LOOKUP_CLIENT_NAME_COL = 16;
-    public static final int LOOKUP_ACCOUNT_NO_COL = 17;
-    public static final int LOOKUP_PRODUCT_COL = 18;
-    public static final int LOOKUP_OPENING_BALANCE_COL = 19;
-    public static final int LOOKUP_SAVINGS_ACTIVATION_DATE_COL = 20;
-    public static final int LOOKUP_SAVINGS_ID_COL = 21;
+    public static final int NOTES_COL = 14;
+    public static final int STATUS_COL = 15;
+    public static final int FAILURE_REPORT_COL = 16;
+    public static final int LOOKUP_CLIENT_NAME_COL = 17;
+    public static final int LOOKUP_ACCOUNT_NO_COL = 18;
+    public static final int LOOKUP_PRODUCT_COL = 19;
+    public static final int LOOKUP_OPENING_BALANCE_COL = 20;
+    public static final int LOOKUP_SAVINGS_ACTIVATION_DATE_COL = 21;
+    public static final int LOOKUP_SAVINGS_ID_COL = 22;
 
     // Transaction type constants
     public static final String TRANSACTION_TYPE_WITHDRAWAL = "Withdrawal";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/savings/SavingsTransactionImportHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/savings/SavingsTransactionImportHandler.java
@@ -61,6 +61,7 @@ public class SavingsTransactionImportHandler implements ImportHandler {
     private Workbook workbook;
     private List<SavingsAccountTransactionData> savingsTransactions;
     private List<String> transactionReferences;
+    private List<String> transactionNotes;
 
     private final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
     private final SavingsAccountTransactionRepository savingsAccountTransactionRepository;
@@ -82,6 +83,7 @@ public class SavingsTransactionImportHandler implements ImportHandler {
         this.workbook = workbook;
         this.savingsTransactions = new ArrayList<>();
         this.transactionReferences = new ArrayList<>();
+        this.transactionNotes = new ArrayList<>();
 
         try {
             readExcelFile(locale, dateFormat);
@@ -143,6 +145,9 @@ public class SavingsTransactionImportHandler implements ImportHandler {
                     // Read and store transaction reference for duplicate checking
                     String transactionReference = ImportHandlerUtils.readAsString(TransactionConstants.TRANSACTION_REFERENCE_COL, row);
                     transactionReferences.add(transactionReference);
+                    // Read and store notes separately
+                    String note = ImportHandlerUtils.readAsString(TransactionConstants.NOTES_COL, row);
+                    transactionNotes.add(note);
 
                 } catch (RuntimeException ex) {
 
@@ -151,6 +156,7 @@ public class SavingsTransactionImportHandler implements ImportHandler {
                     // Add null to keep indices aligned, will be handled in importEntity
                     savingsTransactions.add(null);
                     transactionReferences.add(null);
+                    transactionNotes.add(null);
                     // Write error to the row - ensure row exists
                     Row errorRow = savingsTransactionSheet.getRow(rowIndex);
                     if (errorRow == null) {
@@ -245,6 +251,7 @@ public class SavingsTransactionImportHandler implements ImportHandler {
         for (int i = 0; i < savingsTransactions.size(); i++) {
             SavingsAccountTransactionData transaction = savingsTransactions.get(i);
             String transactionReference = transactionReferences.get(i);
+            String note = transactionNotes.get(i);
 
             // Skip transactions that had errors during reading (null entries)
             if (transaction == null) {
@@ -290,8 +297,14 @@ public class SavingsTransactionImportHandler implements ImportHandler {
                 savingsTransactionJsonob.remove("lienTransaction");
                 savingsTransactionJsonob.remove("chargesPaidByData");
 
-                // Add transaction reference to payload
+                // Add transaction reference to payload for duplicate checking
                 savingsTransactionJsonob.addProperty("refNo", transactionReference);
+                // Add externalReference for display in Transaction Details (External ID field)
+                savingsTransactionJsonob.addProperty("externalReference", transactionReference);
+                // Add note for display in Transaction Details (Notes field) - use separate notes column if provided
+                if (note != null && !note.trim().isEmpty()) {
+                    savingsTransactionJsonob.addProperty("note", note);
+                }
 
                 String payload = savingsTransactionJsonob.toString();
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/savings/SavingsTransactionsWorkbookPopulator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/savings/SavingsTransactionsWorkbookPopulator.java
@@ -235,6 +235,7 @@ public class SavingsTransactionsWorkbookPopulator extends AbstractWorkbookPopula
         worksheet.setColumnWidth(TransactionConstants.RECEIPT_NO_COL, 3000);
         worksheet.setColumnWidth(TransactionConstants.BANK_NO_COL, 3000);
         worksheet.setColumnWidth(TransactionConstants.TRANSACTION_REFERENCE_COL, 5000);
+        worksheet.setColumnWidth(TransactionConstants.NOTES_COL, 5000);
         worksheet.setColumnWidth(TransactionConstants.STATUS_COL, 4000);
         worksheet.setColumnWidth(TransactionConstants.LOOKUP_CLIENT_NAME_COL, 5000);
         worksheet.setColumnWidth(TransactionConstants.LOOKUP_ACCOUNT_NO_COL, 3000);
@@ -279,6 +280,7 @@ public class SavingsTransactionsWorkbookPopulator extends AbstractWorkbookPopula
         writeString(TransactionConstants.RECEIPT_NO_COL, rowHeader, "Receipt No");
         writeString(TransactionConstants.BANK_NO_COL, rowHeader, "Bank No");
         writeString(TransactionConstants.TRANSACTION_REFERENCE_COL, rowHeader, "Transaction Reference*");
+        writeString(TransactionConstants.NOTES_COL, rowHeader, "Notes");
         writeString(TransactionConstants.STATUS_COL, rowHeader, "Status");
         writeString(TransactionConstants.LOOKUP_CLIENT_NAME_COL, rowHeader, "Lookup Client");
         writeString(TransactionConstants.LOOKUP_ACCOUNT_NO_COL, rowHeader, "Lookup Account");
@@ -288,3 +290,4 @@ public class SavingsTransactionsWorkbookPopulator extends AbstractWorkbookPopula
         writeString(TransactionConstants.LOOKUP_SAVINGS_ID_COL, rowHeader, "Lookup Savings ID");
     }
 }
+

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -516,6 +516,11 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         final SavingsAccountTransaction withdrawal = this.savingsAccountDomainService.handleWithdrawal(account, fmt, transactionDate,
                 transactionAmount, paymentDetail, transactionBooleanValues, backdatedTxnsAllowedTill, isAccountTransfer, null);
 
+        // Set external reference if provided (for both manual and bulk import transactions)
+        if (StringUtils.isNotBlank(txnExternalId)) {
+            withdrawal.updateExternalReference(txnExternalId);
+        }
+
         if (isGsim && (withdrawal.getId() != null)) {
 
             validateValtTribeTransactionShouldNotBeBeforeExistingTransaction(transactionDate, account);


### PR DESCRIPTION
https://fiterio.atlassian.net/browse/FSO-467
This pull request enhances the savings transactions bulk import functionality by introducing support for an optional "Notes" column in the import template and ensuring that both "Notes" and "External Reference" fields are correctly processed and persisted during import. The changes update column indices, data extraction, payload construction, and workbook template to accommodate the new feature.

**Bulk Import Template and Data Handling Improvements:**

* Added a new `NOTES_COL` constant to `TransactionConstants`, shifted subsequent column indices, and updated all relevant references to reflect the new column order.
* Updated `SavingsTransactionImportHandler` to extract notes from the new column during file reading, maintain alignment in internal lists, and include the note in the transaction JSON payload if provided. [[1]](diffhunk://#diff-60c237d656df3fae40a7b9763c9aa243074b2f6e33c9c5950be8dec8986f675eR64) [[2]](diffhunk://#diff-60c237d656df3fae40a7b9763c9aa243074b2f6e33c9c5950be8dec8986f675eR86) [[3]](diffhunk://#diff-60c237d656df3fae40a7b9763c9aa243074b2f6e33c9c5950be8dec8986f675eR148-R150) [[4]](diffhunk://#diff-60c237d656df3fae40a7b9763c9aa243074b2f6e33c9c5950be8dec8986f675eR159) [[5]](diffhunk://#diff-60c237d656df3fae40a7b9763c9aa243074b2f6e33c9c5950be8dec8986f675eR254) [[6]](diffhunk://#diff-60c237d656df3fae40a7b9763c9aa243074b2f6e33c9c5950be8dec8986f675eL293-R307)

**Workbook Template Updates:**

* Modified `SavingsTransactionsWorkbookPopulator` to add the "Notes" column header and set its width in the generated Excel template. [[1]](diffhunk://#diff-5a59f39320d8d278997d0039e25fe3151d3a8f1dc32bfe31a1c7aa884e68a4d9R238) [[2]](diffhunk://#diff-5a59f39320d8d278997d0039e25fe3151d3a8f1dc32bfe31a1c7aa884e68a4d9R283) [[3]](diffhunk://#diff-5a59f39320d8d278997d0039e25fe3151d3a8f1dc32bfe31a1c7aa884e68a4d9R293)

**Persistence Enhancements:**

* Ensured that the external reference (transaction reference) is set on the transaction entity during withdrawal processing, supporting both manual and bulk-imported transactions.