### PR TITLE
Add CLI (Credit Life Insurance) charge slabs and related functionality to loan products

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/api/ChargesApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/api/ChargesApiConstants.java
@@ -28,5 +28,6 @@ public final class ChargesApiConstants {
     public static final String taxGroupIdParamName = "taxGroupId";
     public static final String graceExtensionParamName = "graceExtension";
     public static final String graceExtensionDaysParamName = "extensionDays";
+    public static final String isCLIChargeParamName = "isCLICharge";
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/data/ChargeData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/data/ChargeData.java
@@ -94,6 +94,7 @@ public final class ChargeData implements Comparable<ChargeData>, Serializable {
     private List<ChargeSlabData> charges;
     private Integer maxOccurrence;
     private boolean isGraceExtension;
+    private boolean isCLICharge;
 
     public static ChargeData template(final Collection<CurrencyData> currencyOptions,
             final List<EnumOptionData> chargeCalculationTypeOptions, final List<EnumOptionData> chargeAppliesToOptions,
@@ -115,7 +116,7 @@ public final class ChargeData implements Comparable<ChargeData>, Serializable {
                 savingsChargeCalculationTypeOptions, savingsChargeTimeTypeOptions, clientChargeCalculationTypeOptions,
                 clientChargeTimeTypeOptions, null, null, null, null, null, feeFrequencyOptions, account, incomeOrLiabilityAccountOptions,
                 taxGroupOptions, shareChargeCalculationTypeOptions, shareChargeTimeTypeOptions, accountMappingForChargeConfig,
-                expenseAccountOptions, assetAccountOptions, null, null, periodTypes, null, null, null, false);
+                expenseAccountOptions, assetAccountOptions, null, null, periodTypes, null, null, null, false, false);
     }
 
     public static ChargeData withTemplate(final ChargeData charge, final ChargeData template) {
@@ -130,7 +131,7 @@ public final class ChargeData implements Comparable<ChargeData>, Serializable {
                 charge.incomeOrLiabilityAccount, template.incomeOrLiabilityAccountOptions, template.taxGroupOptions,
                 template.shareChargeCalculationTypeOptions, template.shareChargeTimeTypeOptions, template.accountMappingForChargeConfig,
                 template.expenseAccountOptions, template.assetAccountOptions, charge.minAmount, charge.maxAmount, template.periodTypes,
-                charge.varyAmounts, charge.charges, charge.maxOccurrence, charge.isGraceExtension);
+                charge.varyAmounts, charge.charges, charge.maxOccurrence, charge.isGraceExtension, charge.isCLICharge);
     }
 
     public static ChargeData instance(final Long id, final String name, final BigDecimal amount, final CurrencyData currency,
@@ -140,7 +141,7 @@ public final class ChargeData implements Comparable<ChargeData>, Serializable {
             final Integer restartFrequencyEnum, final boolean isPaymentType, final PaymentTypeData paymentTypeOptions,
             final BigDecimal minCap, final BigDecimal maxCap, final EnumOptionData feeFrequency, final GLAccountData accountData,
             TaxGroupData taxGroupData, final BigDecimal minAmount, final BigDecimal maxAmount, Boolean varyAmounts, Integer maxOccurrence,
-            boolean isGraceExtension) {
+            boolean isGraceExtension, boolean isCLICharge) {
 
         final Collection<CurrencyData> currencyOptions = null;
         final List<EnumOptionData> chargeCalculationTypeOptions = null;
@@ -170,7 +171,7 @@ public final class ChargeData implements Comparable<ChargeData>, Serializable {
                 clientChargeTimeTypeOptions, feeOnMonthDay, feeInterval, minCap, maxCap, feeFrequency, feeFrequencyOptions, accountData,
                 incomeOrLiabilityAccountOptions, taxGroupOptions, shareChargeCalculationTypeOptions, shareChargeTimeTypeOptions,
                 accountMappingForChargeConfig, expenseAccountOptions, assetAccountOptions, minAmount, maxAmount, periodTypes, varyAmounts,
-                null, maxOccurrence, isGraceExtension);
+                null, maxOccurrence, isGraceExtension, isCLICharge);
     }
 
     public static ChargeData lookup(final Long id, final String name, final boolean isPenalty) {
@@ -226,7 +227,7 @@ public final class ChargeData implements Comparable<ChargeData>, Serializable {
                 clientChargeTimeTypeOptions, feeOnMonthDay, feeInterval, minCap, maxCap, feeFrequency, feeFrequencyOptions, account,
                 incomeOrLiabilityAccountOptions, taxGroupOptions, shareChargeCalculationTypeOptions, shareChargeTimeTypeOptions,
                 accountMappingForChargeConfig, expenseAccountOptions, assetAccountOptions, minAmount, maxAmount, periodTypes, varyAmounts,
-                null, null, false);
+                null, null, false, false);
     }
 
     private ChargeData(final Long id, final String name, final BigDecimal amount, final CurrencyData currency,
@@ -247,7 +248,7 @@ public final class ChargeData implements Comparable<ChargeData>, Serializable {
             final String accountMappingForChargeConfig, final List<GLAccountData> expenseAccountOptions,
             final List<GLAccountData> assetAccountOptions, final BigDecimal minAmount, final BigDecimal maxAmount,
             final Collection<EnumOptionData> periodTypes, final Boolean varyAmounts, final List<ChargeSlabData> charges,
-            final Integer maxOccurrence, boolean isGraceExtension) {
+            final Integer maxOccurrence, boolean isGraceExtension, boolean isCLICharge) {
         this.id = id;
         this.name = name;
         this.amount = amount;
@@ -297,6 +298,7 @@ public final class ChargeData implements Comparable<ChargeData>, Serializable {
         this.charges = charges;
         this.maxOccurrence = maxOccurrence;
         this.isGraceExtension = isGraceExtension;
+        this.isCLICharge = isCLICharge;
     }
 
     @Override
@@ -428,5 +430,9 @@ public final class ChargeData implements Comparable<ChargeData>, Serializable {
 
     public boolean isActive() {
         return active;
+    }
+
+    public boolean isCLICharge() {
+        return isCLICharge;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/domain/Charge.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/domain/Charge.java
@@ -160,6 +160,9 @@ public class Charge extends AbstractPersistableCustom {
     @Column(name = "is_grace_extention", nullable = false)
     private boolean isGraceExtention;
 
+    @Column(name = "is_cli_charge", nullable = false)
+    private boolean isCLICharge;
+
     @OneToMany(mappedBy = "charge", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<ChargeSlab> chargeSlabs = new HashSet<>();
 
@@ -213,11 +216,12 @@ public class Charge extends AbstractPersistableCustom {
         }
 
         final Integer maxOccurrence = command.integerValueOfParameterNamed("maxOccurrence");
+        final boolean isCLICharge = command.booleanPrimitiveValueOfParameterNamed("isCLICharge");
 
         return new Charge(name, amount, currencyCode, chargeAppliesTo, chargeTimeType, chargeCalculationType, penalty, active, paymentMode,
                 feeOnMonthDay, feeInterval, minCap, maxCap, feeFrequency, enableFreeWithdrawalCharge, freeWithdrawalFrequency,
                 restartCountFrequency, countFrequencyType, account, taxGroup, enablePaymentType, paymentType, minAmount, maxAmount,
-                chargeVarying, maxOccurrence, isGraceExtention);
+                chargeVarying, maxOccurrence, isGraceExtention, isCLICharge);
     }
 
     protected Charge() {}
@@ -229,7 +233,7 @@ public class Charge extends AbstractPersistableCustom {
             final Integer freeWithdrawalFrequency, final Integer restartFrequency, final PeriodFrequencyType restartFrequencyEnum,
             final GLAccount account, final TaxGroup taxGroup, final boolean enablePaymentType, final PaymentType paymentType,
             final BigDecimal minAmount, final BigDecimal maxAmount, Boolean hasVaryingCharge, Integer maxOccurrence,
-            boolean isGraceExtention) {
+            boolean isGraceExtention, boolean isCLICharge) {
         this.name = name;
         this.amount = amount;
         this.minAmount = minAmount;
@@ -324,6 +328,7 @@ public class Charge extends AbstractPersistableCustom {
         }
         this.hasVaryingCharge = hasVaryingCharge;
         this.maxOccurrence = maxOccurrence;
+        this.isCLICharge = isCLICharge;
     }
 
     public String getName() {
@@ -682,6 +687,13 @@ public class Charge extends AbstractPersistableCustom {
             this.isGraceExtention = newValue;
         }
 
+        final String isCLIChargeParamName = "isCLICharge";
+        if (command.isChangeInBooleanParameterNamed(isCLIChargeParamName, this.isCLICharge)) {
+            final boolean newValue = command.booleanPrimitiveValueOfParameterNamed(isCLIChargeParamName);
+            actualChanges.put(isCLIChargeParamName, newValue);
+            this.isCLICharge = newValue;
+        }
+
         final String activeParamName = "active";
         if (command.isChangeInBooleanParameterNamed(activeParamName, this.active)) {
             final boolean newValue = command.booleanPrimitiveValueOfParameterNamed(activeParamName);
@@ -774,7 +786,7 @@ public class Charge extends AbstractPersistableCustom {
                 chargePaymentmode, getFeeOnMonthDay(), this.feeInterval, this.penalty, this.active, this.enableFreeWithdrawal,
                 this.freeWithdrawalFrequency, this.restartFrequency, this.restartFrequencyEnum, this.enablePaymentType, paymentTypeData,
                 this.minCap, this.maxCap, feeFrequencyType, accountData, taxGroupData, this.minAmount, this.maxAmount,
-                this.hasVaryingCharge, null, this.isGraceExtention);
+                this.hasVaryingCharge, this.maxOccurrence, this.isGraceExtention, this.isCLICharge);
     }
 
     public void updateChargeSlabs(JsonCommand command, final Map<String, Object> actualChanges,
@@ -992,5 +1004,13 @@ public class Charge extends AbstractPersistableCustom {
 
     public void setGraceExtention(boolean graceExtention) {
         isGraceExtention = graceExtention;
+    }
+
+    public boolean isCLICharge() {
+        return isCLICharge;
+    }
+
+    public void setCLICharge(boolean cliCharge) {
+        isCLICharge = cliCharge;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializer.java
@@ -61,7 +61,7 @@ public final class ChargeDefinitionCommandFromApiJsonDeserializer {
             "enableFreeWithdrawalCharge", "freeWithdrawalFrequency", "restartCountFrequency", "countFrequencyType", "paymentTypeId",
             "enablePaymentType", "minAmount", "maxAmount", "maxOccurrence", "chart", ChargesApiConstants.glAccountIdParamName,
             ChargesApiConstants.taxGroupIdParamName, ChargesApiConstants.graceExtensionParamName,
-            ChargesApiConstants.graceExtensionDaysParamName));
+            ChargesApiConstants.graceExtensionDaysParamName, ChargesApiConstants.isCLIChargeParamName));
 
     private final FromJsonHelper fromApiJsonHelper;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformServiceImpl.java
@@ -295,7 +295,7 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
 
         public String chargeSchema() {
             return "c.id as id, c.name as name, c.amount as amount, c.currency_code as currencyCode, "
-                    + "c.is_grace_extention as isGraceExtension, "
+                    + "c.is_grace_extention as isGraceExtension, c.is_cli_charge as isCLICharge, "
                     + "c.charge_applies_to_enum as chargeAppliesTo, c.charge_time_enum as chargeTime, "
                     + "c.charge_payment_mode_enum as chargePaymentMode, " + "c.max_occurrence as maxOccurrence, "
                     + "c.charge_calculation_enum as chargeCalculation, c.is_penalty as penalty, "
@@ -398,6 +398,7 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
 
             final String paymentTypeName = rs.getString("paymentTypeName");
             final boolean isGraceExtension = rs.getBoolean("isGraceExtension");
+            final boolean isCLICharge = rs.getBoolean("isCLICharge");
             final Boolean varyAmounts = rs.getBoolean("varyAmounts");
             PaymentTypeData paymentTypeData = null;
             if (paymentTypeId != null) {
@@ -408,7 +409,7 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
             return ChargeData.instance(id, name, amount, currency, chargeTimeType, chargeAppliesToType, chargeCalculationType,
                     chargePaymentMode, feeOnMonthDay, feeInterval, penalty, active, isFreeWithdrawal, freeWithdrawalChargeFrequency,
                     restartFrequency, restartFrequencyEnum, isPaymentType, paymentTypeData, minCap, maxCap, feeFrequencyType, glAccountData,
-                    taxGroupData, minAmount, maxAmount, varyAmounts, maxOccurrence, isGraceExtension);
+                    taxGroupData, minAmount, maxAmount, varyAmounts, maxOccurrence, isGraceExtension, isCLICharge);
         }
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
@@ -140,9 +140,11 @@ import org.apache.fineract.portfolio.loanaccount.service.LoanBulkForeclosureServ
 import org.apache.fineract.portfolio.loanaccount.service.LoanChargeReadPlatformService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanReadPlatformService;
 import org.apache.fineract.portfolio.loanproduct.LoanProductConstants;
+import org.apache.fineract.portfolio.loanproduct.data.CLIChargeSlabData;
 import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
 import org.apache.fineract.portfolio.loanproduct.data.TransactionProcessingStrategyData;
 import org.apache.fineract.portfolio.loanproduct.domain.InterestMethod;
+import org.apache.fineract.portfolio.loanproduct.service.CLIChargeSlabReadPlatformService;
 import org.apache.fineract.portfolio.loanproduct.service.LoanDropdownReadPlatformService;
 import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
 import org.apache.fineract.portfolio.note.data.NoteData;
@@ -232,7 +234,8 @@ public class LoansApiResource {
             "isFloatingInterestRate", "interestRatesPeriods", LoanApiConstants.canUseForTopup, LoanApiConstants.isTopup,
             LoanApiConstants.loanIdToClose, LoanApiConstants.topupAmount, LoanApiConstants.clientActiveLoanOptions,
             LoanApiConstants.datatables, LoanProductConstants.RATES_PARAM_NAME, LoanApiConstants.MULTIDISBURSE_DETAILS_PARAMNAME,
-            LoanApiConstants.EMI_AMOUNT_VARIATIONS_PARAMNAME, LoanApiConstants.COLLECTION_PARAMNAME, "linkedVendorAccount"));
+            LoanApiConstants.EMI_AMOUNT_VARIATIONS_PARAMNAME, LoanApiConstants.COLLECTION_PARAMNAME, "linkedVendorAccount",
+            "cliChargeSlabs"));
 
     private final Set<String> loanApprovalDataParameters = new HashSet<>(Arrays.asList("approvalDate", "approvalAmount"));
     final Set<String> glimAccountsDataParameters = new HashSet<>(Arrays.asList("glimId", "groupId", "clientId", "parentLoanAccountNo",
@@ -271,6 +274,7 @@ public class LoansApiResource {
     private final GLIMAccountInfoReadPlatformService glimAccountInfoReadPlatformService;
     private final LoanCollateralManagementReadPlatformService loanCollateralManagementReadPlatformService;
     private final InterestRateChartReadPlatformService chartReadPlatformService;
+    private final CLIChargeSlabReadPlatformService cliChargeSlabReadPlatformService;
     private final ClientReadPlatformService clientReadPlatformService;
     private final DefaultToApiJsonSerializer<LoanForeclosureEligibleData> loanForeclosureEligibleDataDefaultToApiJsonSerializer;
 
@@ -305,6 +309,7 @@ public class LoansApiResource {
             final GLIMAccountInfoReadPlatformService glimAccountInfoReadPlatformService,
             final LoanCollateralManagementReadPlatformService loanCollateralManagementReadPlatformService,
             final ClientReadPlatformService clientReadPlatformService, InterestRateChartReadPlatformService chartReadPlatformService,
+            CLIChargeSlabReadPlatformService cliChargeSlabReadPlatformService,
             DefaultToApiJsonSerializer<LoanTransactionData> loanTransactionApiJsonSerializer,
             DefaultToApiJsonSerializer<LoanForeclosureEligibleData> loanForeclosureEligibleDataDefaultToApiJsonSerializer,
             LoanBulkForeclosureService loanBulkForeclosureService,
@@ -342,6 +347,7 @@ public class LoansApiResource {
         this.glimAccountInfoReadPlatformService = glimAccountInfoReadPlatformService;
         this.loanCollateralManagementReadPlatformService = loanCollateralManagementReadPlatformService;
         this.chartReadPlatformService = chartReadPlatformService;
+        this.cliChargeSlabReadPlatformService = cliChargeSlabReadPlatformService;
         this.clientReadPlatformService = clientReadPlatformService;
         this.loanTransactionApiJsonSerializer = loanTransactionApiJsonSerializer;
         this.loanForeclosureEligibleDataDefaultToApiJsonSerializer = loanForeclosureEligibleDataDefaultToApiJsonSerializer;
@@ -505,6 +511,10 @@ public class LoansApiResource {
             final Collection<InterestRateChartData> charts = this.chartReadPlatformService
                     .retrieveAllWithSlabsWithTemplateForLoan(productId);
             newLoanAccount.setInterestRateCharts(charts);
+
+            // Retrieve CLI (Credit Life Insurance) charge slabs for the loan product
+            final Collection<CLIChargeSlabData> cliSlabs = this.cliChargeSlabReadPlatformService.retrieveAllByLoanProductId(productId);
+            newLoanAccount.setCliChargeSlabs(cliSlabs);
         }
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanAccountData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanAccountData.java
@@ -47,6 +47,7 @@ import org.apache.fineract.portfolio.interestratechart.data.InterestRateChartSla
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.apache.fineract.portfolio.loanaccount.guarantor.data.GuarantorData;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanScheduleData;
+import org.apache.fineract.portfolio.loanproduct.data.CLIChargeSlabData;
 import org.apache.fineract.portfolio.loanproduct.data.LoanProductBorrowerCycleVariationData;
 import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
 import org.apache.fineract.portfolio.loanproduct.data.TransactionProcessingStrategyData;
@@ -244,6 +245,9 @@ public final class LoanAccountData {
     private final CollectionData delinquent;
 
     private Collection<InterestRateChartSlabData> interestRateChartSlabData;
+
+    // CLI (Credit Life Insurance) charge slabs from loan product
+    private Collection<CLIChargeSlabData> cliChargeSlabs;
 
     private Collection<ClientData> vendorClientOptions;
     private Collection<PortfolioAccountData> vendorSavingsAccountOptions;
@@ -2062,5 +2066,13 @@ public final class LoanAccountData {
 
     public void setLinkedVendorAccount(PortfolioAccountData linkedVendorAccount) {
         this.linkedVendorAccount = linkedVendorAccount;
+    }
+
+    public Collection<CLIChargeSlabData> getCliChargeSlabs() {
+        return cliChargeSlabs;
+    }
+
+    public void setCliChargeSlabs(Collection<CLIChargeSlabData> cliChargeSlabs) {
+        this.cliChargeSlabs = cliChargeSlabs;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanCharge.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanCharge.java
@@ -495,6 +495,46 @@ public class LoanCharge extends AbstractPersistableCustom {
         update(amount, dueDate, amountPercentageAppliedTo, numberOfRepayments, BigDecimal.ZERO);
     }
 
+    /**
+     * Updates the percentage rate for this loan charge and recalculates the amount.
+     * This is used for CLI (Credit Life Insurance) charges where the rate is dynamically
+     * resolved based on loan tenor and amount at disbursement time.
+     *
+     * @param newPercentage the new percentage rate to apply
+     */
+    public void updatePercentage(final BigDecimal newPercentage) {
+        if (newPercentage == null || !isPercentageBasedCharge()) {
+            return;
+        }
+
+        this.percentage = newPercentage;
+        this.amountOrPercentage = newPercentage;
+
+        // Recalculate the charge amount based on the new percentage
+        if (this.loan != null && this.amountPercentageAppliedTo != null) {
+            BigDecimal loanCharge = percentageOf(this.amountPercentageAppliedTo);
+            this.amount = minimumAndMaximumCap(loanCharge);
+            this.amountOutstanding = calculateOutstanding();
+
+            if (isInstalmentFee()) {
+                updateInstallmentCharges();
+            }
+        }
+    }
+
+    /**
+     * Checks if this charge is calculated based on a percentage.
+     *
+     * @return true if the charge calculation is percentage-based
+     */
+    private boolean isPercentageBasedCharge() {
+        ChargeCalculationType calcType = ChargeCalculationType.fromInt(this.chargeCalculation);
+        return calcType == ChargeCalculationType.PERCENT_OF_AMOUNT
+                || calcType == ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST
+                || calcType == ChargeCalculationType.PERCENT_OF_INTEREST
+                || calcType == ChargeCalculationType.PERCENT_OF_DISBURSEMENT_AMOUNT;
+    }
+
     public Map<String, Object> update(final JsonCommand command, final BigDecimal amount) {
 
         final Map<String, Object> actualChanges = new LinkedHashMap<>(7);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
@@ -219,6 +219,7 @@ import org.apache.fineract.portfolio.loanaccount.serialization.LoanUpdateCommand
 import org.apache.fineract.portfolio.loanproduct.data.LoanOverdueDTO;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.portfolio.loanproduct.exception.InvalidCurrencyException;
+import org.apache.fineract.portfolio.loanproduct.service.CLIChargeSlabReadPlatformService;
 import org.apache.fineract.portfolio.loanproduct.exception.LinkedAccountRequiredException;
 import org.apache.fineract.portfolio.note.domain.Note;
 import org.apache.fineract.portfolio.note.domain.NoteRepository;
@@ -286,6 +287,7 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
     private final RepaymentWithPostDatedChecksAssembler repaymentWithPostDatedChecksAssembler;
     private final PostDatedChecksRepository postDatedChecksRepository;
     private final AccountingProcessorHelper helper;
+    private final CLIChargeSlabReadPlatformService cliChargeSlabReadPlatformService;
     private static final Logger LOG = LoggerFactory.getLogger(LoanWritePlatformServiceJpaRepositoryImpl.class);
 
     @Autowired
@@ -385,6 +387,9 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
             if (loanProduct.syncExpectedWithDisbursementDate()) {
                 syncExpectedDateWithActualDisbursementDate(loan, actualDisbursementDate);
             }
+
+            // Resolve CLI (Credit Life Insurance) rates based on loan tenor and amount
+            resolveCLIChargeRates(loan, loanProduct);
 
             for (final LoanCharge loanCharge : loan.charges()) {
                 if (loanCharge.isDisburseToSavings()) {
@@ -3569,6 +3574,84 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
         LOG.error("Error due to Exception", dve);
         throw new PlatformDataIntegrityException("error.msg.loan.unknown.data.integrity.issue",
                 "Unknown data integrity issue with resource: " + realCause.getMessage());
+    }
+
+    /**
+     * Resolves CLI (Credit Life Insurance) charge rates based on loan tenor and amount.
+     * For CLI charges that have configured rate slabs on the loan product, this method
+     * looks up the applicable rate and updates the loan charge percentage.
+     *
+     * @param loan the loan being disbursed
+     * @param loanProduct the loan product associated with the loan
+     */
+    private void resolveCLIChargeRates(final Loan loan, final LoanProduct loanProduct) {
+        if (loan.charges() == null || loan.charges().isEmpty()) {
+            return;
+        }
+
+        // Calculate loan tenor in months
+        final Integer tenorInMonths = calculateLoanTenorInMonths(loan);
+        final BigDecimal loanAmount = loan.getProposedPrincipal();
+        final Long loanProductId = loanProduct.getId();
+
+        for (final LoanCharge loanCharge : loan.charges()) {
+            // Check if the charge is a CLI charge
+            if (loanCharge.getCharge() != null && loanCharge.getCharge().isCLICharge()) {
+                final Long chargeId = loanCharge.getCharge().getId();
+
+                // Resolve the CLI rate from the configured slabs
+                final BigDecimal resolvedRate = this.cliChargeSlabReadPlatformService.resolveCLIRate(
+                        loanProductId, chargeId, tenorInMonths, loanAmount);
+
+                if (resolvedRate != null) {
+                    // Update the loan charge with the resolved rate
+                    loanCharge.updatePercentage(resolvedRate);
+                    log.info("CLI charge {} rate resolved to {}% for loan {} (tenor: {} months, amount: {})",
+                            chargeId, resolvedRate, loan.getId(), tenorInMonths, loanAmount);
+                } else {
+                    log.debug("No matching CLI slab found for charge {} on loan {} (tenor: {} months, amount: {}). Using default charge rate.",
+                            chargeId, loan.getId(), tenorInMonths, loanAmount);
+                }
+            }
+        }
+    }
+
+    /**
+     * Calculates the loan tenor in months based on number of repayments and repayment frequency.
+     *
+     * @param loan the loan to calculate tenor for
+     * @return the loan tenor in months
+     */
+    private Integer calculateLoanTenorInMonths(final Loan loan) {
+        final Integer numberOfRepayments = loan.getLoanRepaymentScheduleDetail().getNumberOfRepayments();
+        final Integer repayEvery = loan.getLoanRepaymentScheduleDetail().getRepayEvery();
+        final PeriodFrequencyType repaymentFrequencyType = loan.getLoanRepaymentScheduleDetail().getRepaymentPeriodFrequencyType();
+
+        if (numberOfRepayments == null || repayEvery == null) {
+            return 0;
+        }
+
+        int tenorInMonths;
+        switch (repaymentFrequencyType) {
+            case DAYS:
+                // Convert days to approximate months (assuming 30 days per month)
+                tenorInMonths = (numberOfRepayments * repayEvery) / 30;
+                break;
+            case WEEKS:
+                // Convert weeks to approximate months (assuming 4 weeks per month)
+                tenorInMonths = (numberOfRepayments * repayEvery) / 4;
+                break;
+            case MONTHS:
+                tenorInMonths = numberOfRepayments * repayEvery;
+                break;
+            case YEARS:
+                tenorInMonths = numberOfRepayments * repayEvery * 12;
+                break;
+            default:
+                tenorInMonths = numberOfRepayments;
+        }
+
+        return Math.max(tenorInMonths, 1); // Minimum 1 month
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/LoanProductConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/LoanProductConstants.java
@@ -155,4 +155,7 @@ public interface LoanProductConstants {
     String LOAN_PRODUCT_CATEGORY = "productCategoryId";
 
     String LOAN_PRODUCT_TYPE = "productTypeId";
+
+    // CLI (Credit Life Insurance) Charge Slabs
+    String CLI_CHARGE_SLABS_PARAM_NAME = "cliChargeSlabs";
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResource.java
@@ -77,10 +77,12 @@ import org.apache.fineract.portfolio.interestratechart.data.InterestRateChartDat
 import org.apache.fineract.portfolio.interestratechart.service.InterestRateChartReadPlatformService;
 import org.apache.fineract.portfolio.loanaccount.api.LoanApiConstants;
 import org.apache.fineract.portfolio.loanproduct.LoanProductConstants;
+import org.apache.fineract.portfolio.loanproduct.data.CLIChargeSlabData;
 import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
 import org.apache.fineract.portfolio.loanproduct.data.TransactionProcessingStrategyData;
 import org.apache.fineract.portfolio.loanproduct.productmix.data.ProductMixData;
 import org.apache.fineract.portfolio.loanproduct.productmix.service.ProductMixReadPlatformService;
+import org.apache.fineract.portfolio.loanproduct.service.CLIChargeSlabReadPlatformService;
 import org.apache.fineract.portfolio.loanproduct.service.LoanDropdownReadPlatformService;
 import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
 import org.apache.fineract.portfolio.paymenttype.data.PaymentTypeData;
@@ -111,7 +113,8 @@ public class LoanProductsApiResource {
             "isLinkedToFloatingInterestRates", "floatingRatesId", "interestRateDifferential", "minDifferentialLendingRate",
             "defaultDifferentialLendingRate", "maxDifferentialLendingRate", "isFloatingInterestRateCalculationAllowed",
             LoanProductConstants.CAN_USE_FOR_TOPUP, LoanProductConstants.IS_EQUAL_AMORTIZATION_PARAM, LoanProductConstants.RATES_PARAM_NAME,
-            LoanApiConstants.fixedPrincipalPercentagePerInstallmentParamName, LoanProductConstants.LOAN_TERM_INCLUDES_TOPPED_UP_LOAN_TERM));
+            LoanApiConstants.fixedPrincipalPercentagePerInstallmentParamName, LoanProductConstants.LOAN_TERM_INCLUDES_TOPPED_UP_LOAN_TERM,
+            "cliChargeSlabs", "interestRateCharts"));
 
     private final Set<String> productMixDataParameters = new HashSet<>(
             Arrays.asList("productId", "productName", "restrictedProducts", "allowedProducts", "productOptions"));
@@ -138,6 +141,7 @@ public class LoanProductsApiResource {
     private final ConfigurationDomainService configurationDomainService;
     private final InterestRateChartReadPlatformService chartReadPlatformService;
     private final CodeValueReadPlatformService codeValueReadPlatformService;
+    private final CLIChargeSlabReadPlatformService cliChargeSlabReadPlatformService;
 
     @Autowired
     public LoanProductsApiResource(final PlatformSecurityContext context, final LoanProductReadPlatformService readPlatformService,
@@ -154,7 +158,7 @@ public class LoanProductsApiResource {
             PaymentTypeReadPlatformService paymentTypeReadPlatformService,
             final FloatingRatesReadPlatformService floatingRateReadPlatformService, final RateReadService rateReadService,
             final ConfigurationDomainService configurationDomainService, InterestRateChartReadPlatformService chartReadPlatformService,
-            CodeValueReadPlatformService codeValueReadPlatformService) {
+            CodeValueReadPlatformService codeValueReadPlatformService, CLIChargeSlabReadPlatformService cliChargeSlabReadPlatformService) {
         this.context = context;
         this.loanProductReadPlatformService = readPlatformService;
         this.chargeReadPlatformService = chargeReadPlatformService;
@@ -175,6 +179,7 @@ public class LoanProductsApiResource {
         this.configurationDomainService = configurationDomainService;
         this.chartReadPlatformService = chartReadPlatformService;
         this.codeValueReadPlatformService = codeValueReadPlatformService;
+        this.cliChargeSlabReadPlatformService = cliChargeSlabReadPlatformService;
     }
 
     @POST
@@ -298,6 +303,11 @@ public class LoanProductsApiResource {
         }
         final Collection<InterestRateChartData> charts = this.chartReadPlatformService.retrieveAllWithSlabsWithTemplateForLoan(productId);
         loanProduct.setInterestRateCharts(charts);
+
+        // Retrieve CLI charge slabs for this loan product
+        final Collection<CLIChargeSlabData> cliSlabs = this.cliChargeSlabReadPlatformService.retrieveAllByLoanProductId(productId);
+        loanProduct.setCliChargeSlabs(cliSlabs);
+
         return this.toApiJsonSerializer.serialize(settings, loanProduct, this.loanProductDataParameters);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/data/CLIChargeSlabData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/data/CLIChargeSlabData.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.data;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+
+/**
+ * DTO for CLI (Credit Life Insurance) Charge Slab configuration.
+ * Used in loan product API requests and responses.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CLIChargeSlabData implements Serializable {
+
+    private Long id;
+    private Long chargeId;
+    private String chargeName;
+    private Integer fromPeriod;
+    private Integer toPeriod;
+    private EnumOptionData periodType;
+    private BigDecimal amountRangeFrom;
+    private BigDecimal amountRangeTo;
+    private BigDecimal rate;
+
+    public static CLIChargeSlabData instance(Long id, Long chargeId, String chargeName,
+            Integer fromPeriod, Integer toPeriod, EnumOptionData periodType,
+            BigDecimal amountRangeFrom, BigDecimal amountRangeTo, BigDecimal rate) {
+        return CLIChargeSlabData.builder()
+                .id(id)
+                .chargeId(chargeId)
+                .chargeName(chargeName)
+                .fromPeriod(fromPeriod)
+                .toPeriod(toPeriod)
+                .periodType(periodType)
+                .amountRangeFrom(amountRangeFrom)
+                .amountRangeTo(amountRangeTo)
+                .rate(rate)
+                .build();
+    }
+}
+

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/data/LoanProductData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/data/LoanProductData.java
@@ -209,6 +209,9 @@ public class LoanProductData implements Serializable {
     private Collection<InterestRateChartData> interestRateCharts;
     private InterestRateChartData activeChart;
 
+    // CLI (Credit Life Insurance) charge slabs
+    private Collection<CLIChargeSlabData> cliChargeSlabs;
+
     private Boolean isBnplLoanProduct;
     private Boolean requiresEquityContribution;
     private BigDecimal equityContributionLoanPercentage;
@@ -1468,5 +1471,13 @@ public class LoanProductData implements Serializable {
 
     public Long getProductCategoryId() {
         return productCategoryId;
+    }
+
+    public Collection<CLIChargeSlabData> getCliChargeSlabs() {
+        return cliChargeSlabs;
+    }
+
+    public void setCliChargeSlabs(Collection<CLIChargeSlabData> cliChargeSlabs) {
+        this.cliChargeSlabs = cliChargeSlabs;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/CLIChargeSlab.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/CLIChargeSlab.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.domain;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
+import org.apache.fineract.portfolio.charge.domain.Charge;
+import org.apache.fineract.portfolio.savings.SavingsPeriodFrequencyType;
+
+@Entity
+@Table(name = "m_product_loan_cli_slab")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CLIChargeSlab extends AbstractPersistableCustom {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "loan_product_id", nullable = false)
+    private LoanProduct loanProduct;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "charge_id", nullable = false)
+    private Charge charge;
+
+    @Column(name = "from_period")
+    private Integer fromPeriod;
+
+    @Column(name = "to_period")
+    private Integer toPeriod;
+
+    @Column(name = "period_type_enum", nullable = false)
+    private Integer periodType;
+
+    @Column(name = "amount_range_from", scale = 6, precision = 19)
+    private BigDecimal amountRangeFrom;
+
+    @Column(name = "amount_range_to", scale = 6, precision = 19)
+    private BigDecimal amountRangeTo;
+
+    @Column(name = "rate", scale = 6, precision = 19, nullable = false)
+    private BigDecimal rate;
+
+    public static List<CLIChargeSlab> assembleFrom(JsonArray cliSlabsArray, LoanProduct loanProduct, Charge charge) {
+        List<CLIChargeSlab> slabs = new ArrayList<>();
+        if (cliSlabsArray == null) return slabs;
+
+        for (JsonElement element : cliSlabsArray) {
+            JsonObject slabObj = element.getAsJsonObject();
+            CLIChargeSlab slab = new CLIChargeSlab();
+            slab.setLoanProduct(loanProduct);
+            slab.setCharge(charge);
+            slab.setFromPeriod(getIntOrNull(slabObj, "fromPeriod"));
+            slab.setToPeriod(getIntOrNull(slabObj, "toPeriod"));
+            slab.setPeriodType(getIntOrDefault(slabObj, "periodType", SavingsPeriodFrequencyType.MONTHS.getValue()));
+            slab.setAmountRangeFrom(getBigDecimalOrNull(slabObj, "amountRangeFrom"));
+            slab.setAmountRangeTo(getBigDecimalOrNull(slabObj, "amountRangeTo"));
+            slab.setRate(slabObj.get("rate").getAsBigDecimal());
+            slabs.add(slab);
+        }
+        return slabs;
+    }
+
+    private static Integer getIntOrNull(JsonObject obj, String key) {
+        return obj.has(key) && !obj.get(key).isJsonNull() ? obj.get(key).getAsInt() : null;
+    }
+
+    private static Integer getIntOrDefault(JsonObject obj, String key, Integer defaultVal) {
+        return obj.has(key) && !obj.get(key).isJsonNull() ? obj.get(key).getAsInt() : defaultVal;
+    }
+
+    private static BigDecimal getBigDecimalOrNull(JsonObject obj, String key) {
+        return obj.has(key) && !obj.get(key).isJsonNull() ? obj.get(key).getAsBigDecimal() : null;
+    }
+
+    public boolean isApplicable(Integer tenorInMonths, BigDecimal loanAmount) {
+        return isApplicableForTenor(tenorInMonths) && isApplicableForAmount(loanAmount);
+    }
+
+    public boolean isApplicableForTenor(Integer tenorInMonths) {
+        if (tenorInMonths == null) return false;
+        boolean fromOk = (this.fromPeriod == null || tenorInMonths >= this.fromPeriod);
+        boolean toOk = (this.toPeriod == null || tenorInMonths <= this.toPeriod);
+        return fromOk && toOk;
+    }
+
+    public boolean isApplicableForAmount(BigDecimal loanAmount) {
+        if (loanAmount == null) return true;
+        boolean fromOk = (this.amountRangeFrom == null || loanAmount.compareTo(this.amountRangeFrom) >= 0);
+        boolean toOk = (this.amountRangeTo == null || loanAmount.compareTo(this.amountRangeTo) <= 0);
+        return fromOk && toOk;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CLIChargeSlab)) return false;
+        CLIChargeSlab that = (CLIChargeSlab) o;
+        return Objects.equals(fromPeriod, that.fromPeriod) && Objects.equals(toPeriod, that.toPeriod) &&
+               Objects.equals(amountRangeFrom, that.amountRangeFrom) && Objects.equals(amountRangeTo, that.amountRangeTo) &&
+               Objects.equals(rate, that.rate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fromPeriod, toPeriod, amountRangeFrom, amountRangeTo, rate);
+    }
+}
+

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/CLIChargeSlabRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/CLIChargeSlabRepository.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public interface CLIChargeSlabRepository extends JpaRepository<CLIChargeSlab, Long>, JpaSpecificationExecutor<CLIChargeSlab> {
+
+    List<CLIChargeSlab> findByLoanProductId(Long loanProductId);
+
+    List<CLIChargeSlab> findByLoanProductIdAndChargeId(Long loanProductId, Long chargeId);
+
+    @Query("SELECT c FROM CLIChargeSlab c WHERE c.loanProduct.id = :loanProductId AND c.charge.id = :chargeId ORDER BY c.fromPeriod ASC")
+    List<CLIChargeSlab> findByLoanProductAndChargeOrderByPeriod(@Param("loanProductId") Long loanProductId, @Param("chargeId") Long chargeId);
+
+    @Modifying
+    @Transactional
+    void deleteByLoanProductId(Long loanProductId);
+
+    @Modifying
+    @Transactional
+    void deleteByLoanProductIdAndChargeId(Long loanProductId, Long chargeId);
+}
+

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
@@ -118,7 +118,7 @@ public final class LoanProductDataValidator {
             DepositsApiConstants.chartsParamName, LoanProductConstants.advancePaymentInterestForExactDaysInPeriodParamName,
             LoanProductConstants.isBnplLoanProductParamName, LoanProductConstants.requiresEquityContributionParamName,
             LoanProductConstants.equityContributionLoanPercentageParamName, LoanProductConstants.LOAN_PRODUCT_CATEGORY,
-            LoanProductConstants.LOAN_PRODUCT_TYPE));
+            LoanProductConstants.LOAN_PRODUCT_TYPE, LoanProductConstants.CLI_CHARGE_SLABS_PARAM_NAME));
 
     private static final String[] supportedloanConfigurableAttributes = { LoanProductConstants.amortizationTypeParamName,
             LoanProductConstants.interestTypeParamName, LoanProductConstants.transactionProcessingStrategyIdParamName,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/CLIChargeSlabReadPlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/CLIChargeSlabReadPlatformService.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.service;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import org.apache.fineract.portfolio.loanproduct.data.CLIChargeSlabData;
+
+public interface CLIChargeSlabReadPlatformService {
+
+    /**
+     * Retrieve all CLI slabs for a loan product
+     */
+    Collection<CLIChargeSlabData> retrieveAllByLoanProductId(Long loanProductId);
+
+    /**
+     * Retrieve CLI slabs for a specific charge in a loan product
+     */
+    Collection<CLIChargeSlabData> retrieveByLoanProductIdAndChargeId(Long loanProductId, Long chargeId);
+
+    /**
+     * Resolve the applicable CLI rate based on tenor and loan amount
+     * @param loanProductId the loan product
+     * @param chargeId the CLI charge
+     * @param tenorInMonths loan tenor in months
+     * @param loanAmount the loan principal amount
+     * @return the applicable CLI rate percentage, or null if no matching slab
+     */
+    BigDecimal resolveCLIRate(Long loanProductId, Long chargeId, Integer tenorInMonths, BigDecimal loanAmount);
+}
+

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/CLIChargeSlabReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/CLIChargeSlabReadPlatformServiceImpl.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.service;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.interestratechart.service.InterestRateChartEnumerations;
+import org.apache.fineract.portfolio.loanproduct.data.CLIChargeSlabData;
+import org.apache.fineract.portfolio.loanproduct.domain.CLIChargeSlab;
+import org.apache.fineract.portfolio.loanproduct.domain.CLIChargeSlabRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CLIChargeSlabReadPlatformServiceImpl implements CLIChargeSlabReadPlatformService {
+
+    private final PlatformSecurityContext context;
+    private final JdbcTemplate jdbcTemplate;
+    private final CLIChargeSlabRepository cliChargeSlabRepository;
+    private final CLIChargeSlabMapper slabMapper = new CLIChargeSlabMapper();
+
+    @Autowired
+    public CLIChargeSlabReadPlatformServiceImpl(PlatformSecurityContext context, JdbcTemplate jdbcTemplate,
+            CLIChargeSlabRepository cliChargeSlabRepository) {
+        this.context = context;
+        this.jdbcTemplate = jdbcTemplate;
+        this.cliChargeSlabRepository = cliChargeSlabRepository;
+    }
+
+    @Override
+    public Collection<CLIChargeSlabData> retrieveAllByLoanProductId(Long loanProductId) {
+        this.context.authenticatedUser();
+        final String sql = "SELECT " + slabMapper.schema() + " WHERE cs.loan_product_id = ? ORDER BY cs.charge_id, cs.from_period";
+        return this.jdbcTemplate.query(sql, slabMapper, loanProductId);
+    }
+
+    @Override
+    public Collection<CLIChargeSlabData> retrieveByLoanProductIdAndChargeId(Long loanProductId, Long chargeId) {
+        this.context.authenticatedUser();
+        final String sql = "SELECT " + slabMapper.schema() + " WHERE cs.loan_product_id = ? AND cs.charge_id = ? ORDER BY cs.from_period";
+        return this.jdbcTemplate.query(sql, slabMapper, loanProductId, chargeId);
+    }
+
+    @Override
+    public BigDecimal resolveCLIRate(Long loanProductId, Long chargeId, Integer tenorInMonths, BigDecimal loanAmount) {
+        List<CLIChargeSlab> slabs = cliChargeSlabRepository.findByLoanProductAndChargeOrderByPeriod(loanProductId, chargeId);
+
+        for (CLIChargeSlab slab : slabs) {
+            if (slab.isApplicable(tenorInMonths, loanAmount)) {
+                return slab.getRate();
+            }
+        }
+        return null; // No matching slab found
+    }
+
+    private static final class CLIChargeSlabMapper implements RowMapper<CLIChargeSlabData> {
+
+        public String schema() {
+            return "cs.id as id, cs.charge_id as chargeId, c.name as chargeName, " +
+                   "cs.from_period as fromPeriod, cs.to_period as toPeriod, cs.period_type_enum as periodType, " +
+                   "cs.amount_range_from as amountRangeFrom, cs.amount_range_to as amountRangeTo, cs.rate as rate " +
+                   "FROM m_product_loan_cli_slab cs " +
+                   "JOIN m_charge c ON c.id = cs.charge_id ";
+        }
+
+        @Override
+        public CLIChargeSlabData mapRow(ResultSet rs, int rowNum) throws SQLException {
+            final Long id = rs.getLong("id");
+            final Long chargeId = rs.getLong("chargeId");
+            final String chargeName = rs.getString("chargeName");
+            final Integer fromPeriod = rs.getObject("fromPeriod") != null ? rs.getInt("fromPeriod") : null;
+            final Integer toPeriod = rs.getObject("toPeriod") != null ? rs.getInt("toPeriod") : null;
+            final Integer periodTypeId = rs.getObject("periodType") != null ? rs.getInt("periodType") : null;
+            final BigDecimal amountRangeFrom = rs.getBigDecimal("amountRangeFrom");
+            final BigDecimal amountRangeTo = rs.getBigDecimal("amountRangeTo");
+            final BigDecimal rate = rs.getBigDecimal("rate");
+
+            EnumOptionData periodType = null;
+            if (periodTypeId != null) {
+                periodType = InterestRateChartEnumerations.periodType(periodTypeId);
+            }
+
+            return CLIChargeSlabData.instance(id, chargeId, chargeName, fromPeriod, toPeriod, periodType,
+                    amountRangeFrom, amountRangeTo, rate);
+        }
+    }
+}
+

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductWritePlatformServiceJpaRepositoryImpl.java
@@ -62,6 +62,8 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionProcessin
 import org.apache.fineract.portfolio.loanaccount.exception.LoanTransactionProcessingStrategyNotFoundException;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.AprCalculator;
 import org.apache.fineract.portfolio.loanproduct.LoanProductConstants;
+import org.apache.fineract.portfolio.loanproduct.domain.CLIChargeSlab;
+import org.apache.fineract.portfolio.loanproduct.domain.CLIChargeSlabRepository;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRepository;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanTransactionProcessingStrategy;
@@ -107,6 +109,8 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
 
     private final CodeValueRepositoryWrapper codeValueRepository;
 
+    private final CLIChargeSlabRepository cliChargeSlabRepository;
+
     @Autowired
     public LoanProductWritePlatformServiceJpaRepositoryImpl(final PlatformSecurityContext context,
             final LoanProductDataValidator fromApiJsonDeserializer, final LoanProductRepository loanProductRepository,
@@ -117,7 +121,7 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
             final FineractEntityAccessUtil fineractEntityAccessUtil, final FloatingRateRepositoryWrapper floatingRateRepository,
             final LoanRepositoryWrapper loanRepositoryWrapper, final BusinessEventNotifierService businessEventNotifierService,
             DepositProductAssembler depositProductAssembler, InterestRateChartAssembler chartAssembler,
-            CodeValueRepositoryWrapper codeValueRepository) {
+            CodeValueRepositoryWrapper codeValueRepository, CLIChargeSlabRepository cliChargeSlabRepository) {
         this.context = context;
         this.fromApiJsonDeserializer = fromApiJsonDeserializer;
         this.loanProductRepository = loanProductRepository;
@@ -134,6 +138,7 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
         this.depositProductAssembler = depositProductAssembler;
         this.chartAssembler = chartAssembler;
         this.codeValueRepository = codeValueRepository;
+        this.cliChargeSlabRepository = cliChargeSlabRepository;
     }
 
     @Transactional
@@ -176,6 +181,9 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
             loanProduct.setCharts(charts);
 
             this.loanProductRepository.saveAndFlush(loanProduct);
+
+            // Handle CLI charge slabs
+            assembleCLIChargeSlabs(command, loanProduct);
 
             // save accounting mappings
             this.accountMappingWritePlatformService.createLoanProductToGLAccountMapping(loanProduct.getId(), command);
@@ -246,6 +254,7 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
 
             final Map<String, Object> changes = product.update(command, this.aprCalculator, floatingRate);
             this.updateCharts(command, changes, product);
+            this.updateCLIChargeSlabs(command, product, changes);
             if (changes.containsKey("fundId")) {
                 final Long fundId = (Long) changes.get("fundId");
                 final Fund fund = findFundByIdIfProvided(fundId);
@@ -486,5 +495,71 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
                     productTypeId);
         }
         return productType;
+    }
+
+    /**
+     * Assemble and save CLI (Credit Life Insurance) charge slabs from JSON command.
+     * Expected JSON format in request:
+     * {
+     *   "cliChargeSlabs": [
+     *     {
+     *       "chargeId": 1,
+     *       "slabs": [
+     *         { "fromPeriod": 1, "toPeriod": 6, "amountRangeTo": 100000000, "rate": 0.9 },
+     *         { "fromPeriod": 7, "toPeriod": 12, "amountRangeTo": 100000000, "rate": 1.0 },
+     *         { "fromPeriod": 13, "toPeriod": 24, "amountRangeTo": 100000000, "rate": 1.2 }
+     *       ]
+     *     }
+     *   ]
+     * }
+     */
+    private void assembleCLIChargeSlabs(JsonCommand command, LoanProduct loanProduct) {
+        if (!command.parameterExists("cliChargeSlabs")) {
+            return;
+        }
+
+        // Delete existing CLI slabs for this loan product
+        this.cliChargeSlabRepository.deleteByLoanProductId(loanProduct.getId());
+
+        final JsonArray cliChargeSlabsArray = command.arrayOfParameterNamed("cliChargeSlabs");
+        if (cliChargeSlabsArray == null || cliChargeSlabsArray.size() == 0) {
+            return;
+        }
+
+        List<CLIChargeSlab> allSlabs = new ArrayList<>();
+
+        for (int i = 0; i < cliChargeSlabsArray.size(); i++) {
+            final JsonObject cliChargeObj = cliChargeSlabsArray.get(i).getAsJsonObject();
+
+            if (!cliChargeObj.has("chargeId")) {
+                continue;
+            }
+
+            final Long chargeId = cliChargeObj.get("chargeId").getAsLong();
+            final Charge charge = this.chargeRepository.findOneWithNotFoundDetection(chargeId);
+
+            if (cliChargeObj.has("slabs") && cliChargeObj.get("slabs").isJsonArray()) {
+                final JsonArray slabsArray = cliChargeObj.getAsJsonArray("slabs");
+                List<CLIChargeSlab> slabs = CLIChargeSlab.assembleFrom(slabsArray, loanProduct, charge);
+                allSlabs.addAll(slabs);
+            }
+        }
+
+        if (!allSlabs.isEmpty()) {
+            this.cliChargeSlabRepository.saveAll(allSlabs);
+        }
+    }
+
+    /**
+     * Update CLI charge slabs for an existing loan product
+     */
+    private void updateCLIChargeSlabs(JsonCommand command, LoanProduct loanProduct, Map<String, Object> actualChanges) {
+        if (!command.parameterExists("cliChargeSlabs")) {
+            return;
+        }
+
+        // Reassemble CLI slabs (delete and recreate)
+        assembleCLIChargeSlabs(command, loanProduct);
+        actualChanges.put("cliChargeSlabs", "updated");
     }
 }

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -97,5 +97,7 @@
 <!--    <include file="parts/FSO_363_optimize_datatable_scoping_indexes.xml" relativeToChangelogFile="true" />-->
     <include file="parts/FSO_373_bulk_foreclosure_job_tables.xml" relativeToChangelogFile="true" />
     <include file="parts/FSO-366_add_account_name_to_payment_detail.xml" relativeToChangelogFile="true" />
+    <include file="parts/oxy-51_cli_charge_slab_table.xml" relativeToChangelogFile="true" />
+    <include file="parts/oxy-52_add_is_cli_charge_column.xml" relativeToChangelogFile="true" />
     <includeAll path="custom-changelog" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/oxy-51_cli_charge_slab_table.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/oxy-51_cli_charge_slab_table.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <!-- Create CLI Charge Slab table for loan product charge configuration -->
+    <changeSet author="deepika@fiter.io" id="oxy_51_cli_charge_slab_table">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="m_product_loan_cli_slab" />
+            </not>
+        </preConditions>
+
+        <createTable tableName="m_product_loan_cli_slab">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="loan_product_id" type="BIGINT">
+                <constraints nullable="false" foreignKeyName="FK_m_product_loan_cli_slab_product" references="m_product_loan(id)"/>
+            </column>
+            <column name="charge_id" type="BIGINT">
+                <constraints nullable="false" foreignKeyName="FK_m_product_loan_cli_slab_charge" references="m_charge(id)"/>
+            </column>
+            <column name="from_period" type="INT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="to_period" type="INT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="period_type_enum" type="SMALLINT" defaultValueNumeric="2">
+                <constraints nullable="false"/>
+            </column>
+            <column name="amount_range_from" type="DECIMAL(19,6)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="amount_range_to" type="DECIMAL(19,6)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="rate" type="DECIMAL(19,6)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createIndex tableName="m_product_loan_cli_slab" indexName="idx_cli_slab_product_charge">
+            <column name="loan_product_id"/>
+            <column name="charge_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>
+

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/oxy-52_add_is_cli_charge_column.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/oxy-52_add_is_cli_charge_column.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <!-- Add is_cli_charge column to m_charge table -->
+    <changeSet author="deepika@fiter.io" id="oxy_52_add_is_cli_charge_column">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="m_charge" columnName="is_cli_charge"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="m_charge">
+            <column name="is_cli_charge" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>
+

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanproduct/domain/CLIChargeSlabTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanproduct/domain/CLIChargeSlabTest.java
@@ -1,0 +1,206 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.math.BigDecimal;
+import java.util.List;
+import org.apache.fineract.portfolio.charge.domain.Charge;
+import org.apache.fineract.portfolio.savings.SavingsPeriodFrequencyType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for CLIChargeSlab entity.
+ */
+@ExtendWith(MockitoExtension.class)
+class CLIChargeSlabTest {
+
+    @Mock
+    private LoanProduct loanProduct;
+
+    @Mock
+    private Charge charge;
+
+    private CLIChargeSlab slab;
+
+    @BeforeEach
+    void setUp() {
+        slab = new CLIChargeSlab();
+        slab.setLoanProduct(loanProduct);
+        slab.setCharge(charge);
+        slab.setFromPeriod(1);
+        slab.setToPeriod(6);
+        slab.setPeriodType(SavingsPeriodFrequencyType.MONTHS.getValue());
+        slab.setAmountRangeFrom(BigDecimal.ZERO);
+        slab.setAmountRangeTo(new BigDecimal("100000000"));
+        slab.setRate(new BigDecimal("0.9"));
+    }
+
+    @Test
+    void testIsApplicableForTenor_WithinRange() {
+        assertTrue(slab.isApplicableForTenor(3));
+        assertTrue(slab.isApplicableForTenor(1));
+        assertTrue(slab.isApplicableForTenor(6));
+    }
+
+    @Test
+    void testIsApplicableForTenor_OutsideRange() {
+        assertFalse(slab.isApplicableForTenor(0));
+        assertFalse(slab.isApplicableForTenor(7));
+        assertFalse(slab.isApplicableForTenor(12));
+    }
+
+    @Test
+    void testIsApplicableForTenor_NullTenor() {
+        assertFalse(slab.isApplicableForTenor(null));
+    }
+
+    @Test
+    void testIsApplicableForTenor_NullFromPeriod() {
+        slab.setFromPeriod(null);
+        assertTrue(slab.isApplicableForTenor(3));
+        assertTrue(slab.isApplicableForTenor(1));
+    }
+
+    @Test
+    void testIsApplicableForTenor_NullToPeriod() {
+        slab.setToPeriod(null);
+        assertTrue(slab.isApplicableForTenor(100));
+        assertTrue(slab.isApplicableForTenor(1));
+    }
+
+    @Test
+    void testIsApplicableForAmount_WithinRange() {
+        assertTrue(slab.isApplicableForAmount(new BigDecimal("50000000")));
+        assertTrue(slab.isApplicableForAmount(BigDecimal.ZERO));
+        assertTrue(slab.isApplicableForAmount(new BigDecimal("100000000")));
+    }
+
+    @Test
+    void testIsApplicableForAmount_OutsideRange() {
+        assertFalse(slab.isApplicableForAmount(new BigDecimal("100000001")));
+        assertFalse(slab.isApplicableForAmount(new BigDecimal("200000000")));
+    }
+
+    @Test
+    void testIsApplicableForAmount_NullAmount() {
+        assertTrue(slab.isApplicableForAmount(null));
+    }
+
+    @Test
+    void testIsApplicable_BothConditionsMet() {
+        assertTrue(slab.isApplicable(3, new BigDecimal("50000000")));
+        assertTrue(slab.isApplicable(6, new BigDecimal("100000000")));
+    }
+
+    @Test
+    void testIsApplicable_TenorOutOfRange() {
+        assertFalse(slab.isApplicable(12, new BigDecimal("50000000")));
+    }
+
+    @Test
+    void testIsApplicable_AmountOutOfRange() {
+        assertFalse(slab.isApplicable(3, new BigDecimal("200000000")));
+    }
+
+    @Test
+    void testAssembleFrom_ValidJsonArray() {
+        JsonArray slabsArray = new JsonArray();
+
+        JsonObject slabObj1 = new JsonObject();
+        slabObj1.addProperty("fromPeriod", 1);
+        slabObj1.addProperty("toPeriod", 6);
+        slabObj1.addProperty("amountRangeTo", 100000000);
+        slabObj1.addProperty("rate", 0.9);
+        slabsArray.add(slabObj1);
+
+        JsonObject slabObj2 = new JsonObject();
+        slabObj2.addProperty("fromPeriod", 7);
+        slabObj2.addProperty("toPeriod", 12);
+        slabObj2.addProperty("amountRangeTo", 100000000);
+        slabObj2.addProperty("rate", 1.0);
+        slabsArray.add(slabObj2);
+
+        List<CLIChargeSlab> slabs = CLIChargeSlab.assembleFrom(slabsArray, loanProduct, charge);
+
+        assertNotNull(slabs);
+        assertEquals(2, slabs.size());
+
+        CLIChargeSlab first = slabs.get(0);
+        assertEquals(Integer.valueOf(1), first.getFromPeriod());
+        assertEquals(Integer.valueOf(6), first.getToPeriod());
+        assertEquals(new BigDecimal("0.9"), first.getRate());
+
+        CLIChargeSlab second = slabs.get(1);
+        assertEquals(Integer.valueOf(7), second.getFromPeriod());
+        assertEquals(Integer.valueOf(12), second.getToPeriod());
+        assertEquals(new BigDecimal("1.0"), second.getRate());
+    }
+
+    @Test
+    void testAssembleFrom_NullJsonArray() {
+        List<CLIChargeSlab> slabs = CLIChargeSlab.assembleFrom(null, loanProduct, charge);
+        assertNotNull(slabs);
+        assertTrue(slabs.isEmpty());
+    }
+
+    @Test
+    void testAssembleFrom_EmptyJsonArray() {
+        JsonArray slabsArray = new JsonArray();
+        List<CLIChargeSlab> slabs = CLIChargeSlab.assembleFrom(slabsArray, loanProduct, charge);
+        assertNotNull(slabs);
+        assertTrue(slabs.isEmpty());
+    }
+
+    @Test
+    void testEquals_SameValues() {
+        CLIChargeSlab slab2 = new CLIChargeSlab();
+        slab2.setFromPeriod(1);
+        slab2.setToPeriod(6);
+        slab2.setAmountRangeFrom(BigDecimal.ZERO);
+        slab2.setAmountRangeTo(new BigDecimal("100000000"));
+        slab2.setRate(new BigDecimal("0.9"));
+
+        assertEquals(slab, slab2);
+        assertEquals(slab.hashCode(), slab2.hashCode());
+    }
+
+    @Test
+    void testEquals_DifferentRate() {
+        CLIChargeSlab slab2 = new CLIChargeSlab();
+        slab2.setFromPeriod(1);
+        slab2.setToPeriod(6);
+        slab2.setAmountRangeFrom(BigDecimal.ZERO);
+        slab2.setAmountRangeTo(new BigDecimal("100000000"));
+        slab2.setRate(new BigDecimal("1.0"));
+
+        assertFalse(slab.equals(slab2));
+    }
+}
+

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanproduct/service/CLIChargeSlabReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanproduct/service/CLIChargeSlabReadPlatformServiceImplTest.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.charge.domain.Charge;
+import org.apache.fineract.portfolio.loanproduct.domain.CLIChargeSlab;
+import org.apache.fineract.portfolio.loanproduct.domain.CLIChargeSlabRepository;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
+import org.apache.fineract.portfolio.savings.SavingsPeriodFrequencyType;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for CLIChargeSlabReadPlatformServiceImpl.
+ */
+@ExtendWith(MockitoExtension.class)
+class CLIChargeSlabReadPlatformServiceImplTest {
+
+    @Mock
+    private PlatformSecurityContext context;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private CLIChargeSlabRepository cliChargeSlabRepository;
+
+    @Mock
+    private AppUser appUser;
+
+    @Mock
+    private LoanProduct loanProduct;
+
+    @Mock
+    private Charge charge;
+
+    private CLIChargeSlabReadPlatformServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CLIChargeSlabReadPlatformServiceImpl(context, jdbcTemplate, cliChargeSlabRepository);
+        when(context.authenticatedUser()).thenReturn(appUser);
+    }
+
+    @Test
+    void testResolveCLIRate_MatchingSlabFound() {
+        // Create test slabs
+        List<CLIChargeSlab> slabs = createTestSlabs();
+        when(cliChargeSlabRepository.findByLoanProductAndChargeOrderByPeriod(anyLong(), anyLong())).thenReturn(slabs);
+
+        // Test with 3 months tenor and 50 million loan amount
+        BigDecimal rate = service.resolveCLIRate(1L, 1L, 3, new BigDecimal("50000000"));
+
+        assertNotNull(rate);
+        assertEquals(new BigDecimal("0.9"), rate);
+    }
+
+    @Test
+    void testResolveCLIRate_SecondSlabMatched() {
+        List<CLIChargeSlab> slabs = createTestSlabs();
+        when(cliChargeSlabRepository.findByLoanProductAndChargeOrderByPeriod(anyLong(), anyLong())).thenReturn(slabs);
+
+        // Test with 10 months tenor
+        BigDecimal rate = service.resolveCLIRate(1L, 1L, 10, new BigDecimal("50000000"));
+
+        assertNotNull(rate);
+        assertEquals(new BigDecimal("1.0"), rate);
+    }
+
+    @Test
+    void testResolveCLIRate_ThirdSlabMatched() {
+        List<CLIChargeSlab> slabs = createTestSlabs();
+        when(cliChargeSlabRepository.findByLoanProductAndChargeOrderByPeriod(anyLong(), anyLong())).thenReturn(slabs);
+
+        // Test with 20 months tenor
+        BigDecimal rate = service.resolveCLIRate(1L, 1L, 20, new BigDecimal("50000000"));
+
+        assertNotNull(rate);
+        assertEquals(new BigDecimal("1.2"), rate);
+    }
+
+    @Test
+    void testResolveCLIRate_NoMatchingSlabFound() {
+        List<CLIChargeSlab> slabs = createTestSlabs();
+        when(cliChargeSlabRepository.findByLoanProductAndChargeOrderByPeriod(anyLong(), anyLong())).thenReturn(slabs);
+
+        // Test with 30 months tenor (beyond configured slabs)
+        BigDecimal rate = service.resolveCLIRate(1L, 1L, 30, new BigDecimal("50000000"));
+
+        assertNull(rate);
+    }
+
+    @Test
+    void testResolveCLIRate_EmptySlabs() {
+        when(cliChargeSlabRepository.findByLoanProductAndChargeOrderByPeriod(anyLong(), anyLong())).thenReturn(new ArrayList<>());
+
+        BigDecimal rate = service.resolveCLIRate(1L, 1L, 6, new BigDecimal("50000000"));
+
+        assertNull(rate);
+    }
+
+    @Test
+    void testResolveCLIRate_AmountExceedsSlabRange() {
+        List<CLIChargeSlab> slabs = createTestSlabs();
+        when(cliChargeSlabRepository.findByLoanProductAndChargeOrderByPeriod(anyLong(), anyLong())).thenReturn(slabs);
+
+        // Test with amount exceeding the configured range
+        BigDecimal rate = service.resolveCLIRate(1L, 1L, 3, new BigDecimal("200000000"));
+
+        assertNull(rate);
+    }
+
+    /**
+     * Creates test CLI slabs matching the document specification:
+     * - ≤6 months: 0.9%
+     * - ≤12 months: 1.0%
+     * - ≤24 months: 1.2%
+     */
+    private List<CLIChargeSlab> createTestSlabs() {
+        List<CLIChargeSlab> slabs = new ArrayList<>();
+
+        // First slab: 1-6 months, 0.9%
+        CLIChargeSlab slab1 = new CLIChargeSlab();
+        slab1.setLoanProduct(loanProduct);
+        slab1.setCharge(charge);
+        slab1.setFromPeriod(1);
+        slab1.setToPeriod(6);
+        slab1.setPeriodType(SavingsPeriodFrequencyType.MONTHS.getValue());
+        slab1.setAmountRangeTo(new BigDecimal("100000000"));
+        slab1.setRate(new BigDecimal("0.9"));
+        slabs.add(slab1);
+
+        // Second slab: 7-12 months, 1.0%
+        CLIChargeSlab slab2 = new CLIChargeSlab();
+        slab2.setLoanProduct(loanProduct);
+        slab2.setCharge(charge);
+        slab2.setFromPeriod(7);
+        slab2.setToPeriod(12);
+        slab2.setPeriodType(SavingsPeriodFrequencyType.MONTHS.getValue());
+        slab2.setAmountRangeTo(new BigDecimal("100000000"));
+        slab2.setRate(new BigDecimal("1.0"));
+        slabs.add(slab2);
+
+        // Third slab: 13-24 months, 1.2%
+        CLIChargeSlab slab3 = new CLIChargeSlab();
+        slab3.setLoanProduct(loanProduct);
+        slab3.setCharge(charge);
+        slab3.setFromPeriod(13);
+        slab3.setToPeriod(24);
+        slab3.setPeriodType(SavingsPeriodFrequencyType.MONTHS.getValue());
+        slab3.setAmountRangeTo(new BigDecimal("100000000"));
+        slab3.setRate(new BigDecimal("1.2"));
+        slabs.add(slab3);
+
+        return slabs;
+    }
+}
+


### PR DESCRIPTION
https://fiterio.atlassian.net/browse/FSO-468

This pull request introduces support for a new "CLI Charge" feature in the Charges and Loans modules. The main changes add a new `isCLICharge` property to the charge domain, data, and API layers, update the database mapping, and extend the Loans API to handle CLI charge slabs. These enhancements enable the system to distinguish and manage CLI-specific charges throughout the stack.

**Support for CLI Charges:**

* Added a new boolean field `isCLICharge` to the `Charge` domain model, including database mapping, construction, update logic, and accessors. This allows charges to be flagged as CLI charges in persistence and business logic. [[1]](diffhunk://#diff-98ad234b51307cf6611e6c0852f7b9dffe8cf89ab79c637ab879d24e85343c22R163-R165) [[2]](diffhunk://#diff-98ad234b51307cf6611e6c0852f7b9dffe8cf89ab79c637ab879d24e85343c22R219-R224) [[3]](diffhunk://#diff-98ad234b51307cf6611e6c0852f7b9dffe8cf89ab79c637ab879d24e85343c22L232-R236) [[4]](diffhunk://#diff-98ad234b51307cf6611e6c0852f7b9dffe8cf89ab79c637ab879d24e85343c22R331) [[5]](diffhunk://#diff-98ad234b51307cf6611e6c0852f7b9dffe8cf89ab79c637ab879d24e85343c22R690-R696) [[6]](diffhunk://#diff-98ad234b51307cf6611e6c0852f7b9dffe8cf89ab79c637ab879d24e85343c22L777-R789) [[7]](diffhunk://#diff-98ad234b51307cf6611e6c0852f7b9dffe8cf89ab79c637ab879d24e85343c22R1008-R1015)
* Extended the `ChargeData` DTO and related factory methods to include the `isCLICharge` property, ensuring the value is available in API responses and internal data flows. [[1]](diffhunk://#diff-0ca0db8976a824511b439de7cdf49d856ab1b1b376bf0a87390a926e7969174eR97) [[2]](diffhunk://#diff-0ca0db8976a824511b439de7cdf49d856ab1b1b376bf0a87390a926e7969174eL118-R119) [[3]](diffhunk://#diff-0ca0db8976a824511b439de7cdf49d856ab1b1b376bf0a87390a926e7969174eL133-R134) [[4]](diffhunk://#diff-0ca0db8976a824511b439de7cdf49d856ab1b1b376bf0a87390a926e7969174eL143-R144) [[5]](diffhunk://#diff-0ca0db8976a824511b439de7cdf49d856ab1b1b376bf0a87390a926e7969174eL173-R174) [[6]](diffhunk://#diff-0ca0db8976a824511b439de7cdf49d856ab1b1b376bf0a87390a926e7969174eL229-R230) [[7]](diffhunk://#diff-0ca0db8976a824511b439de7cdf49d856ab1b1b376bf0a87390a926e7969174eL250-R251) [[8]](diffhunk://#diff-0ca0db8976a824511b439de7cdf49d856ab1b1b376bf0a87390a926e7969174eR301) [[9]](diffhunk://#diff-0ca0db8976a824511b439de7cdf49d856ab1b1b376bf0a87390a926e7969174eR434-R437)
* Updated the API constants and deserializer to recognize the new `isCLICharge` parameter, so it can be set and validated via API calls. [[1]](diffhunk://#diff-fe7a63f3d1cd2e51bb3a51fb1aacc20d56ee8786c5bdc8715f8d155e618b1f24R31) [[2]](diffhunk://#diff-80ac1c99867598849dc3d3bf61c34e5cbae441f64d25967937ecb4d7c5c58a81L64-R64)
* Enhanced the charge read platform service and SQL mapping to fetch and map the `isCLICharge` value from the database. [[1]](diffhunk://#diff-26968fa2bb7b4ba2de1195230d73a0de317b822137836f2776ca0fb8c17f3c94L298-R298) [[2]](diffhunk://#diff-26968fa2bb7b4ba2de1195230d73a0de317b822137836f2776ca0fb8c17f3c94R401) [[3]](diffhunk://#diff-26968fa2bb7b4ba2de1195230d73a0de317b822137836f2776ca0fb8c17f3c94L411-R412)

**Loans API Enhancements:**

* Added support for CLI charge slabs in the Loans API by introducing the `cliChargeSlabs` parameter and wiring in the `CLIChargeSlabReadPlatformService`, laying the groundwork for CLI charge slab management in loan products. [[1]](diffhunk://#diff-16a68e2008ee634fbab286e7d2cf5007ac48f3ee79bb49ec5e29fe1c72addb68R143-R147) [[2]](diffhunk://#diff-16a68e2008ee634fbab286e7d2cf5007ac48f3ee79bb49ec5e29fe1c72addb68L235-R238) [[3]](diffhunk://#diff-16a68e2008ee634fbab286e7d2cf5007ac48f3ee79bb49ec5e29fe1c72addb68R277) [[4]](diffhunk://#diff-16a68e2008ee634fbab286e7d2cf5007ac48f3ee79bb49ec5e29fe1c72addb68R312)